### PR TITLE
Specify Maven Java source and target versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,8 @@
     <netty.version>4.1.54.Final-SNAPSHOT</netty.version>
     <netty.build.version>26</netty.build.version>
     <jni.classifier>${os.detected.name}-${os.detected.arch}</jni.classifier>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
   </properties>
 
   <build>


### PR DESCRIPTION
This PR adds explicit Maven source and target Java versions to the pom.xml.

Without this it fails to build in my environment (it appears to default to Java 6)