### PR TITLE
Add docker files to compile io_uring transport

### DIFF
--- a/docker/Dockerfile.centos
+++ b/docker/Dockerfile.centos
@@ -1,0 +1,25 @@
+ARG centos_version=6
+FROM centos:$centos_version
+# needed to do again after FROM due to docker limitation
+ARG centos_version
+
+# install dependencies
+RUN yum install -y \
+ apr-devel \
+ autoconf \
+ automake \
+ git \
+ glibc-devel \
+ libtool \
+ lsb-core \
+ make \
+ tar \
+ wget
+
+ARG java_version=1.8
+ENV JAVA_VERSION $java_version
+# installing java with jabba
+RUN curl -sL https://github.com/shyiko/jabba/raw/master/install.sh | JABBA_COMMAND="install $JAVA_VERSION -o /jdk" bash
+
+RUN echo 'export JAVA_HOME="/jdk"' >> ~/.bashrc
+RUN echo 'PATH=/jdk/bin:$PATH' >> ~/.bashrc

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,11 @@
+# Using the docker images
+
+```
+cd /path/to/source/
+```
+
+## centos 6 with java 8
+
+```
+docker-compose -f docker/docker-compose.yaml -f docker/docker-compose.centos-6.18.yaml run build
+```

--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -1,0 +1,22 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: netty-io_uring:centos-6-1.8
+    build:
+      args:
+        centos_version : "6"
+        java_version : "adopt@1.8.0-272"
+
+  test:
+    image: netty-io_uring:centos-6-1.8
+
+  test-leak:
+    image: netty-io_uring:centos-6-1.8
+
+  build:
+    image: netty-io_uring:centos-6-1.8
+
+  shell:
+    image: netty-io_uring:centos-6-1.8

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,42 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: netty-io_uring:default
+    build:
+      context: .
+      dockerfile: Dockerfile.centos
+
+  common: &common
+    image: netty-io_uring:default
+    depends_on: [runtime-setup]
+    volumes:
+      - ~/.ssh:/root/.ssh:delegated
+      - ~/.gnupg:/root/.gnupg:delegated
+      - ..:/code:delegated
+    working_dir: /code
+
+  test-leak:
+    <<: *common
+    command: /bin/bash -cl "./mvnw -Pleak clean test -Dio.netty.testsuite.badHost=netty.io -Dmaven.wagon.http.pool=false"
+
+  test:
+    <<: *common
+    command: /bin/bash -cl "./mvnw clean test -Dio.netty.testsuite.badHost=netty.io -Dmaven.wagon.http.pool=false"
+
+  build: 
+    <<: *common
+    command: /bin/bash -cl "./mvnw clean package -Dio.netty.testsuite.badHost=netty.io -Dmaven.wagon.http.pool=false"
+
+  shell:
+    <<: *common
+    environment:
+      - SANOTYPE_USER
+      - SANOTYPE_PASSWORD
+    volumes:
+      - ~/.ssh:/root/.ssh:delegated
+      - ~/.gnupg:/root/.gnupg:delegated
+      - ..:/code:delegated
+      - ~/.m2:/root/.m2:delegated
+    entrypoint: /bin/bash


### PR DESCRIPTION
Motivation:

Add docker files that can be used to setup the right env to compile the transport. This can also be used to release as it will ensure we link against the minimum GLIBC version and so make it usable everywhere as long as a recent enough kernel is present.

Modifications:

Add docker files

Result:

Be able to compile easily and release