### PR TITLE
Ensure all Channels are deregistered before we finally shutdown the E…

### DIFF
--- a/src/test/java/io/netty/incubator/channel/uring/PollRemoveTest.java
+++ b/src/test/java/io/netty/incubator/channel/uring/PollRemoveTest.java
@@ -38,11 +38,10 @@ public class PollRemoveTest {
     private void io_uring_test() throws Exception {
         Class<? extends ServerSocketChannel> clazz = IOUringServerSocketChannel.class;
         final EventLoopGroup bossGroup = new IOUringEventLoopGroup(1);
-        final EventLoopGroup workerGroup = new IOUringEventLoopGroup(1);
 
         try {
             ServerBootstrap b = new ServerBootstrap();
-            b.group(bossGroup, workerGroup)
+            b.group(bossGroup)
                     .channel(clazz)
                     .handler(new LoggingHandler(LogLevel.TRACE))
                     .childHandler(new ChannelInitializer<SocketChannel>() {
@@ -51,22 +50,17 @@ public class PollRemoveTest {
                     });
 
             Channel sc = b.bind(2020).sync().channel();
-            Thread.sleep(1500);
 
             // close ServerChannel
             sc.close().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            bossGroup.shutdownGracefully().sync();
         }
     }
 
-    @Test
+    @Test(timeout = 10000)
     public void test() throws Exception {
         io_uring_test();
-
-        Thread.sleep(1000);
-
         io_uring_test();
     }
 }


### PR DESCRIPTION
…ventLoop

Motivation:

We need to wait till all channels are really deregistered before we fianlly shutdown the EventLoop. Failing to do so may lead to the situation that we fail to handle some completions or even not schedule all of these.
Due how io_uring works this may then lead to the situation that the file descriptors are never closed.

Modifications:

- Guard against adding Channels to the IOUringEventLoop when we already shutting it down
- Ensure we close all Channels during shutdown of the IOUringEventLoop
- Wait till we deregistered all of theses and no more tasks should be run
- Adjust testcases to fail before the fix

Result:

Fixes https://github.com/netty/netty-incubator-transport-io_uring/issues/16, https://github.com/netty/netty-incubator-transport-io_uring/issues/5