### PR TITLE
Correctly handle mapped addresses in all cases

### DIFF
--- a/src/main/java/io/netty/incubator/channel/uring/IOUringEventLoop.java
+++ b/src/main/java/io/netty/incubator/channel/uring/IOUringEventLoop.java
@@ -51,8 +51,8 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements IOUringCom
     private final FileDescriptor eventfd;
 
     // The maximum number of bytes for an InetAddress / Inet6Address
-    private final byte[] inet4AddressArray = new byte[4];
-    private final byte[] inet6AddressArray = new byte[16];
+    private final byte[] inet4AddressArray = new byte[SockaddrIn.IPV4_ADDRESS_LENGTH];
+    private final byte[] inet6AddressArray = new byte[SockaddrIn.IPV6_ADDRESS_LENGTH];
 
     private long prevDeadlineNanos = NONE;
     private boolean pendingWakeup;

--- a/src/main/java/io/netty/incubator/channel/uring/IOUringServerSocketChannel.java
+++ b/src/main/java/io/netty/incubator/channel/uring/IOUringServerSocketChannel.java
@@ -24,7 +24,6 @@ import java.net.SocketAddress;
 
 public final class IOUringServerSocketChannel extends AbstractIOUringServerChannel implements ServerSocketChannel {
     private final IOUringServerSocketChannelConfig config;
-    private boolean ipv4;
 
     public IOUringServerSocketChannel() {
         super(LinuxSocket.newSocketStream(), false);
@@ -40,13 +39,9 @@ public final class IOUringServerSocketChannel extends AbstractIOUringServerChann
     Channel newChildChannel(int fd, long acceptedAddressMemoryAddress, long acceptedAddressLengthMemoryAddress) {
         final InetSocketAddress address;
         if (socket.isIpv6()) {
-            if (ipv4) {
-                byte[] addressArray = ((IOUringEventLoop) eventLoop()).inet4AddressArray();
-                address = SockaddrIn.readIPv6MappedIpv4(acceptedAddressMemoryAddress, addressArray);
-            } else {
-                byte[] addressArray = ((IOUringEventLoop) eventLoop()).inet6AddressArray();
-                address = SockaddrIn.readIPv6(acceptedAddressMemoryAddress, addressArray);
-            }
+            byte[] ipv6Array = ((IOUringEventLoop) eventLoop()).inet6AddressArray();
+            byte[] ipv4Array = ((IOUringEventLoop) eventLoop()).inet4AddressArray();
+            address = SockaddrIn.readIPv6(acceptedAddressMemoryAddress, ipv6Array, ipv4Array);
         } else {
             byte[] addressArray = ((IOUringEventLoop) eventLoop()).inet4AddressArray();
             address = SockaddrIn.readIPv4(acceptedAddressMemoryAddress, addressArray);
@@ -67,10 +62,6 @@ public final class IOUringServerSocketChannel extends AbstractIOUringServerChann
     @Override
     public void doBind(SocketAddress localAddress) throws Exception {
         super.doBind(localAddress);
-        SocketAddress local = localAddress0();
-        if (local != null && ((InetSocketAddress) local).getAddress() instanceof Inet4Address) {
-            ipv4 = true;
-        }
         socket.listen(config.getBacklog());
         active = true;
     }

--- a/src/main/java/io/netty/incubator/channel/uring/MsgHdrMemory.java
+++ b/src/main/java/io/netty/incubator/channel/uring/MsgHdrMemory.java
@@ -51,8 +51,10 @@ final class MsgHdrMemory {
         IOUringEventLoop eventLoop = (IOUringEventLoop) channel.eventLoop();
         InetSocketAddress sender;
         if (channel.socket.isIpv6()) {
-            byte[] bytes = eventLoop.inet6AddressArray();
-            sender = SockaddrIn.readIPv6(sockAddress, bytes);
+            byte[] ipv6Bytes = eventLoop.inet6AddressArray();
+            byte[] ipv4bytes = eventLoop.inet4AddressArray();
+
+            sender = SockaddrIn.readIPv6(sockAddress, ipv6Bytes, ipv4bytes);
         } else {
             byte[] bytes = eventLoop.inet4AddressArray();
             sender = SockaddrIn.readIPv4(sockAddress, bytes);

--- a/src/test/java/io/netty/incubator/channel/uring/SockaddrInTest.java
+++ b/src/test/java/io/netty/incubator/channel/uring/SockaddrInTest.java
@@ -20,6 +20,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -60,8 +61,10 @@ public class SockaddrInTest {
                     null, new byte[] { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 }, 12345);
             int port = 45678;
             Assert.assertEquals(Native.SIZEOF_SOCKADDR_IN6, SockaddrIn.writeIPv6(memoryAddress, address, port));
-            byte[] bytes = new byte[16];
-            InetSocketAddress sockAddr = SockaddrIn.readIPv6(memoryAddress, bytes);
+            byte[] ipv6Bytes = new byte[16];
+            byte[] ipv4Bytes = new byte[4];
+
+            InetSocketAddress sockAddr = SockaddrIn.readIPv6(memoryAddress, ipv6Bytes, ipv4Bytes);
             Inet6Address inet6Address = (Inet6Address) sockAddr.getAddress();
             Assert.assertArrayEquals(address.getAddress(), inet6Address.getAddress());
             Assert.assertEquals(address.getScopeId(), inet6Address.getScopeId());
@@ -79,15 +82,15 @@ public class SockaddrInTest {
             InetAddress address = InetAddress.getByAddress(new byte[] { 10, 10, 10, 10 });
             int port = 45678;
             Assert.assertEquals(Native.SIZEOF_SOCKADDR_IN6, SockaddrIn.writeIPv6(memoryAddress, address, port));
-            byte[] bytes = new byte[16];
-            InetSocketAddress sockAddr = SockaddrIn.readIPv6(memoryAddress, bytes);
-            Inet6Address inet6Address = (Inet6Address) sockAddr.getAddress();
+            byte[] ipv6Bytes = new byte[16];
+            byte[] ipv4Bytes = new byte[4];
 
-            System.arraycopy(SockaddrIn.IPV4_MAPPED_IPV6_PREFIX, 0, bytes, 0,
+            InetSocketAddress sockAddr = SockaddrIn.readIPv6(memoryAddress, ipv6Bytes, ipv4Bytes);
+            Inet4Address ipv4Address = (Inet4Address) sockAddr.getAddress();
+
+            System.arraycopy(SockaddrIn.IPV4_MAPPED_IPV6_PREFIX, 0, ipv6Bytes, 0,
                     SockaddrIn.IPV4_MAPPED_IPV6_PREFIX.length);
-            System.arraycopy(address.getAddress(), 0, bytes, SockaddrIn.IPV4_MAPPED_IPV6_PREFIX.length, 4);
-            Assert.assertArrayEquals(bytes, inet6Address.getAddress());
-            Assert.assertEquals(0, inet6Address.getScopeId());
+            Assert.assertArrayEquals(ipv4Bytes, ipv4Address.getAddress());
             Assert.assertEquals(port, sockAddr.getPort());
         } finally {
             Buffer.free(buffer);


### PR DESCRIPTION
Motivation:

#21 tried to fix the handling of ipv6-mapped-ipv4 addresses but did not fix all cases.

Modifications:

- Correctly detect mapped addresses in all cases
- Add more unit tests

Result:

Fixes https://github.com/netty/netty-incubator-transport-io_uring/issues/18 for real