### PR TITLE
Netty 4.1.55.Final is out, we should use it

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     </jni.compiler.args.ldflags>
     <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
     <skipTests>true</skipTests>
-    <netty.version>4.1.54.Final</netty.version>
+    <netty.version>4.1.55.Final</netty.version>
     <netty.build.version>28</netty.build.version>
     <jni.classifier>${os.detected.name}-${os.detected.arch}</jni.classifier>
   </properties>


### PR DESCRIPTION
Motivation:

We just had a new netty release.

Modifications:

Update dependency netty version to 4.1.55.Final

Result:

Use latest version