### PR TITLE
Using a shared linux worker queue

### DIFF
--- a/src/main/c/netty_io_uring_native.c
+++ b/src/main/c/netty_io_uring_native.c
@@ -221,7 +221,7 @@ done:
 static jobjectArray netty_io_uring_setup(JNIEnv *env, jclass clazz, jint entries, jint wqFd) {
     struct io_uring_params params;
     memset(&params, 0, sizeof(params));
-    if (wqFd > 0) {
+    if (wqFd > -1) {
         params.flags = IORING_SETUP_ATTACH_WQ;
         params.wq_fd = wqFd;
     }

--- a/src/main/java/io/netty/incubator/channel/uring/IOUringEventLoop.java
+++ b/src/main/java/io/netty/incubator/channel/uring/IOUringEventLoop.java
@@ -57,14 +57,14 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements IOUringCom
     private long prevDeadlineNanos = NONE;
     private boolean pendingWakeup;
 
-    IOUringEventLoop(IOUringEventLoopGroup parent, Executor executor, int ringSize, int iosqeAsyncThreshold,
+    IOUringEventLoop(IOUringEventLoopGroup parent, Executor executor, RingBuffer ringBuffer,
                      RejectedExecutionHandler rejectedExecutionHandler, EventLoopTaskQueueFactory queueFactory) {
         super(parent, executor, false, newTaskQueue(queueFactory), newTaskQueue(queueFactory),
                 rejectedExecutionHandler);
         // Ensure that we load all native bits as otherwise it may fail when try to use native methods in IovArray
         IOUring.ensureAvailability();
 
-        ringBuffer = Native.createRingBuffer(ringSize, iosqeAsyncThreshold);
+        this.ringBuffer = ringBuffer;
 
         eventfd = Native.newBlockingEventFd();
         logger.trace("New EventLoop: {}", this.toString());

--- a/src/main/java/io/netty/incubator/channel/uring/IOUringEventLoopGroup.java
+++ b/src/main/java/io/netty/incubator/channel/uring/IOUringEventLoopGroup.java
@@ -35,7 +35,7 @@ public final class IOUringEventLoopGroup extends MultithreadEventLoopGroup {
     }
 
     private int childWorkerPoolCounter;
-    private int lastRingFd;
+    private int lastRingFd = -1;
 
     /**
      * Create a new instance using the default number of threads and the default {@link ThreadFactory}.

--- a/src/main/java/io/netty/incubator/channel/uring/IOUringEventLoopGroup.java
+++ b/src/main/java/io/netty/incubator/channel/uring/IOUringEventLoopGroup.java
@@ -37,9 +37,6 @@ public final class IOUringEventLoopGroup extends MultithreadEventLoopGroup {
     private int childWorkerPoolCounter;
     private int lastRingFd;
 
-    //the number of eventLoop which are associated to one work queue
-    private final int MAX_EVENTLOOPS_WQ = 2;
-
     /**
      * Create a new instance using the default number of threads and the default {@link ThreadFactory}.
      */
@@ -126,13 +123,13 @@ public final class IOUringEventLoopGroup extends MultithreadEventLoopGroup {
         EventLoopTaskQueueFactory taskQueueFactory = (EventLoopTaskQueueFactory) args[3];
         RingBuffer ringBuffer;
 
-        if (childWorkerPoolCounter > MAX_EVENTLOOPS_WQ) {
+        if (childWorkerPoolCounter < Native.DEFAULT_MAX_EVENTLOOPS_WQ) {
             ringBuffer = Native.createRingBuffer(ringSize, iosqeAsyncThreshold, lastRingFd);
             childWorkerPoolCounter++;
         } else {
             ringBuffer = Native.createRingBuffer(ringSize, iosqeAsyncThreshold, -1);
-            childWorkerPoolCounter++;
             lastRingFd = ringBuffer.fd();
+            childWorkerPoolCounter = 1;
         }
 
         return new IOUringEventLoop(this, executor, ringBuffer,

--- a/src/main/java/io/netty/incubator/channel/uring/IOUringEventLoopGroup.java
+++ b/src/main/java/io/netty/incubator/channel/uring/IOUringEventLoopGroup.java
@@ -35,7 +35,7 @@ public final class IOUringEventLoopGroup extends MultithreadEventLoopGroup {
     }
 
     private int childWorkerPoolCounter;
-    private int lastRingFd = -1;
+    private int lastRingFd;
 
     /**
      * Create a new instance using the default number of threads and the default {@link ThreadFactory}.

--- a/src/main/java/io/netty/incubator/channel/uring/IOUringEventLoopGroup.java
+++ b/src/main/java/io/netty/incubator/channel/uring/IOUringEventLoopGroup.java
@@ -123,7 +123,7 @@ public final class IOUringEventLoopGroup extends MultithreadEventLoopGroup {
         EventLoopTaskQueueFactory taskQueueFactory = (EventLoopTaskQueueFactory) args[3];
         RingBuffer ringBuffer;
 
-        if (childWorkerPoolCounter < Native.DEFAULT_MAX_EVENTLOOPS_WQ) {
+        if (childWorkerPoolCounter < Native.DEFAULT_MAX_EVENTLOOPS_WQ && lastRingFd != 0) {
             ringBuffer = Native.createRingBuffer(ringSize, iosqeAsyncThreshold, lastRingFd);
             childWorkerPoolCounter++;
         } else {

--- a/src/main/java/io/netty/incubator/channel/uring/Native.java
+++ b/src/main/java/io/netty/incubator/channel/uring/Native.java
@@ -35,7 +35,7 @@ final class Native {
     static final int DEFAULT_IOSEQ_ASYNC_THRESHOLD =
             Math.max(0, SystemPropertyUtil.getInt("io.netty.uring.iosqeAsyncThreshold", 25));
 
-    //the number of eventLoops which are associated to one work queue
+    // The number of eventLoops which are associated to one work queue
     static final int DEFAULT_MAX_EVENTLOOPS_WQ =
             Math.max(0, SystemPropertyUtil.getInt("io.netty.uring.maxEventLoopsWq", 1));
 

--- a/src/main/java/io/netty/incubator/channel/uring/Native.java
+++ b/src/main/java/io/netty/incubator/channel/uring/Native.java
@@ -35,6 +35,10 @@ final class Native {
     static final int DEFAULT_IOSEQ_ASYNC_THRESHOLD =
             Math.max(0, SystemPropertyUtil.getInt("io.netty.uring.iosqeAsyncThreshold", 25));
 
+    //the number of eventLoop which are associated to one work queue
+    static final int DEFAULT_MAX_EVENTLOOPS_WQ =
+            Math.max(0, SystemPropertyUtil.getInt("io.netty.uring.maxEventLoopsWq", 1));
+
     static {
         Selector selector = null;
         try {

--- a/src/main/java/io/netty/incubator/channel/uring/Native.java
+++ b/src/main/java/io/netty/incubator/channel/uring/Native.java
@@ -35,7 +35,7 @@ final class Native {
     static final int DEFAULT_IOSEQ_ASYNC_THRESHOLD =
             Math.max(0, SystemPropertyUtil.getInt("io.netty.uring.iosqeAsyncThreshold", 25));
 
-    //the number of eventLoop which are associated to one work queue
+    //the number of eventLoops which are associated to one work queue
     static final int DEFAULT_MAX_EVENTLOOPS_WQ =
             Math.max(0, SystemPropertyUtil.getInt("io.netty.uring.maxEventLoopsWq", 1));
 

--- a/src/main/java/io/netty/incubator/channel/uring/Native.java
+++ b/src/main/java/io/netty/incubator/channel/uring/Native.java
@@ -134,11 +134,11 @@ final class Native {
     };
 
     static RingBuffer createRingBuffer(int ringSize) {
-        return createRingBuffer(ringSize, DEFAULT_IOSEQ_ASYNC_THRESHOLD);
+        return createRingBuffer(ringSize, DEFAULT_IOSEQ_ASYNC_THRESHOLD, -1);
     }
 
-    static RingBuffer createRingBuffer(int ringSize, int iosqeAsyncThreshold) {
-        long[][] values = ioUringSetup(ringSize);
+    static RingBuffer createRingBuffer(int ringSize, int iosqeAsyncThreshold, int wqFd) {
+        long[][] values = ioUringSetup(ringSize, wqFd);
         assert values.length == 2;
         long[] submissionQueueArgs = values[0];
         assert submissionQueueArgs.length == 11;
@@ -171,7 +171,7 @@ final class Native {
     }
 
     static RingBuffer createRingBuffer() {
-        return createRingBuffer(DEFAULT_RING_SIZE, DEFAULT_IOSEQ_ASYNC_THRESHOLD);
+        return createRingBuffer(DEFAULT_RING_SIZE, DEFAULT_IOSEQ_ASYNC_THRESHOLD, -1);
     }
 
     static void checkAllIOSupported(int ringFd) {
@@ -182,7 +182,7 @@ final class Native {
     }
 
     private static native boolean ioUringProbe(int ringFd, int[] ios);
-    private static native long[][] ioUringSetup(int entries);
+    private static native long[][] ioUringSetup(int entries, int wqFd);
 
     public static native int ioUringEnter(int ringFd, int toSubmit, int minComplete, int flags);
 


### PR DESCRIPTION
Motivation:

on each eventloop 4 kthread worker will be created, to use the wq more efficiently you can attach different ringbuffers( (eventloops) to the same wq(worker queue)

Modifications:

- attach the wqFd to the ring buffer

Result:

using less worker queues