### PR TITLE
Run apt-get update before trying to install dependencies

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,7 +49,7 @@ jobs:
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
     - name: Install tools / libraries 
-      run: sudo apt-get -y install autoconf automake libtool make tar rustc cargo git
+      run: sudo apt-get update && sudo apt-get -y install autoconf automake libtool make tar rustc cargo git
 
     - name: Build project
       run: ./mvnw clean package -DskipTests=true


### PR DESCRIPTION
Motivation:

We need to run apt-get update before trying to install dependencies as otherwise we may see 404 errors

Modifications:

run apt-get update

Result:

No more failures due 404