### PR TITLE
Remove eventfd read async flag

### DIFF
--- a/src/main/java/io/netty/incubator/channel/uring/IOUringEventLoop.java
+++ b/src/main/java/io/netty/incubator/channel/uring/IOUringEventLoop.java
@@ -281,7 +281,7 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements IOUringCom
     }
 
     private void addEventFdRead(IOUringSubmissionQueue submissionQueue) {
-        submissionQueue.addRead(eventfd.intValue(), eventfdReadBuf, 0, 8, (short) 0);
+        submissionQueue.addEventFdRead(eventfd.intValue(), eventfdReadBuf, 0, 8, (short) 0);
     }
 
     private void handleConnect(AbstractIOUringChannel channel, int res) {

--- a/src/main/java/io/netty/incubator/channel/uring/IOUringSubmissionQueue.java
+++ b/src/main/java/io/netty/incubator/channel/uring/IOUringSubmissionQueue.java
@@ -181,6 +181,10 @@ final class IOUringSubmissionQueue {
         return enqueueSqe(Native.IORING_OP_READ, flags(), 0, fd, bufferAddress + pos, limit - pos, 0, extraData);
     }
 
+    boolean addEventFdRead(int fd, long bufferAddress, int pos, int limit, short extraData) {
+        return enqueueSqe(Native.IORING_OP_READ, 0, 0, fd, bufferAddress + pos, limit - pos, 0, extraData);
+    }
+
     boolean addWrite(int fd, long bufferAddress, int pos, int limit, short extraData) {
         return enqueueSqe(Native.IORING_OP_WRITE, flags(), 0, fd, bufferAddress + pos, limit - pos, 0, extraData);
     }


### PR DESCRIPTION
Motivation:

it actually makes no sense to use IOSQE_ASYNC, as eventfd is used to wakeup io_uring_enter

Modifications:

add new eventfd read method in SubmissionQueue

Result:

https://github.com/netty/netty-incubator-transport-io_uring/issues/14 fixed