### PR TITLE
Also build for aarch64 on ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,11 @@ jobs:
       - name: Build docker image
         run: docker-compose -f docker/docker-compose.yaml -f docker/docker-compose.centos-6.18.yaml build
 
-      - name: Execute project build
+      - name: Execute project build (x86_64)
         run: docker-compose -f docker/docker-compose.yaml -f docker/docker-compose.centos-6.18.yaml run build
+
+      - name: Execute project build (aarch64)
+        run: docker-compose -f docker/docker-compose.yaml run cross-compile-aarch64-build
 
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}


### PR DESCRIPTION
Motivation:

We should also build for aarch64

Modifications:

Add step that builds for aarch64

Result:

Make use of docker files