### PR TITLE
Correctly include checkstyle dependencies when download dependencies …

### DIFF
--- a/docker/Dockerfile.centos6
+++ b/docker/Dockerfile.centos6
@@ -36,4 +36,4 @@ ENV JAVA_HOME /jdk/
 
 COPY ./pom.xml $SOURCE_DIR/pom.xml
 WORKDIR $SOURCE_DIR
-RUN /bin/bash -c 'source $HOME/.bashrc && mvn dependency:go-offline surefire:test -ntp'
+RUN /bin/bash -c 'source $HOME/.bashrc && mvn dependency:go-offline checkstyle:check surefire:test -ntp'

--- a/docker/Dockerfile.cross_compile_aarch64
+++ b/docker/Dockerfile.cross_compile_aarch64
@@ -41,4 +41,4 @@ ENV PATH /opt/apache-maven-3.6.3/bin/:$PATH
 
 COPY ./pom.xml $SOURCE_DIR/pom.xml
 WORKDIR $SOURCE_DIR
-RUN /bin/bash -c 'source $HOME/.bashrc && mvn dependency:go-offline surefire:test -ntp'
+RUN /bin/bash -c 'source $HOME/.bashrc && mvn dependency:go-offline checkstyle:check surefire:test -ntp'

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,18 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
           <version>${maven-checkstyle-plugin.version}</version>
+          <dependencies>
+            <dependency>
+              <groupId>com.puppycrawl.tools</groupId>
+              <artifactId>checkstyle</artifactId>
+              <version>${checkstyle.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>io.netty</groupId>
+              <artifactId>netty-build-common</artifactId>
+              <version>${netty.build.version}</version>
+            </dependency>
+          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -270,18 +282,6 @@
             <inherited>false</inherited>
           </execution>
         </executions>
-        <dependencies>
-          <dependency>
-            <groupId>com.puppycrawl.tools</groupId>
-            <artifactId>checkstyle</artifactId>
-            <version>${checkstyle.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-build-common</artifactId>
-            <version>${netty.build.version}</version>
-          </dependency>
-        </dependencies>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
…for offline build

Motivation:

We need to ensure we correctly include the dependencies that are needed for checkstyle.

Modifications:

Include the dependencies

Result:

All present when try to do offline builds