### PR TITLE
Deploy snapshots when build the main branch (#55)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,15 @@ jobs:
           echo "::set-output name=key::$(/bin/date -u "+%Y%U")"
         shell: bash
 
+      - uses: s4u/maven-settings-action@v2.2.0
+        with:
+          servers: |
+            [{
+                "id": "sonatype-nexus-snapshots",
+                "username": "${{ secrets.SONATYPE_USERNAME }}",
+                "password": "${{ secrets.SONATYPE_PASSWORD }}"
+            }]
+
       - uses: actions/checkout@v2
 
       # Enable caching of Docker layers
@@ -38,6 +47,11 @@ jobs:
 
       - name: Execute project build
         run: docker-compose -f docker/docker-compose.yaml -f docker/docker-compose.centos-6.18.yaml run build
+
+      # Deploy if this was a push to the main branch
+      - name: Deploy to sonatype
+        if: ${{ github.event_name == 'push' }}
+        run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml run deploy
 
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}

--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -17,5 +17,8 @@ services:
   build:
     image: netty-io_uring:centos-6-1.8
 
+  deploy:
+    image: netty-io_uring:centos-6-1.8
+
   shell:
     image: netty-io_uring:centos-6-1.8

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -29,6 +29,15 @@ services:
     <<: *common
     command: /bin/bash -cl "mvn clean package -Dio.netty.testsuite.badHost=netty.io"
 
+  deploy:
+    <<: *common
+    command: /bin/bash -cl "mvn clean deploy -DskipTests=true"
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - ~/.gnupg:/root/.gnupg
+      - ~/.m2/settings.xml:/root/.m2/settings.xml
+      - ..:/code
+
   shell:
     <<: *common
     environment:


### PR DESCRIPTION
Motivation:

We should deploy snapshots whenever we build the main branch

Modifications:

- Add config for docker compose to be able to deploy
- Use secrets to setup settings.xml

Result:

Automatically deploy snapshots