### PR TITLE
Let's split up some work in different workflows

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,0 +1,83 @@
+name: Build project
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  schedule:
+    - cron: '30 5 * * 1'  # At 05:30 on Monday, every Monday.
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build-x86_64:
+    runs-on: ubuntu-latest
+    steps:
+      # http://man7.org/linux/man-pages/man1/date.1.html
+      - name: Create Cache Key
+        id: cache-key
+        run: |
+          echo "::set-output name=key::$(/bin/date -u "+%Y%U")"
+        shell: bash
+
+      - uses: actions/checkout@v2
+
+      # Enable caching of Docker layers
+      - uses: satackey/action-docker-layer-caching@v0.0.8
+        continue-on-error: true
+        with:
+          key: docker-cache-${{ steps.cache-key.outputs.key }}-{hash}
+          restore-keys: |
+            docker-cache-${{ steps.cache-key.outputs.key }}-
+
+      - name: Build docker image
+        run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml build
+
+      - name: Build project without leak detection
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml run build
+
+      - name: Build project with leak detection
+        if: ${{ github.event_name == 'pull_request' }}
+        run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml run build-leak
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: target_x86_64
+          path: target/ # or path/to/artifact
+
+  build-aarch64:
+    runs-on: ubuntu-latest
+    steps:
+      # http://man7.org/linux/man-pages/man1/date.1.html
+      - name: Create Cache Key
+        id: cache-key
+        run: |
+          echo "::set-output name=key::$(/bin/date -u "+%Y%U")"
+        shell: bash
+
+      - uses: actions/checkout@v2
+
+      # Enable caching of Docker layers
+      - uses: satackey/action-docker-layer-caching@v0.0.8
+        continue-on-error: true
+        with:
+          key: docker-cache-${{ steps.cache-key.outputs.key }}-{hash}
+          restore-keys: |
+            docker-cache-${{ steps.cache-key.outputs.key }}-
+
+      - name: Build docker image
+        run: docker-compose -f docker/docker-compose.centos-7.yaml build
+
+      - name: Build project
+        run: docker-compose -f docker/docker-compose.centos-7.yaml run cross-compile-aarch64-build
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: target_aarch64
+          path: target/ # or path/to/artifact

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -13,25 +13,18 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-x86_64:
+  build-linux-x86_64:
     runs-on: ubuntu-latest
     steps:
-      # http://man7.org/linux/man-pages/man1/date.1.html
-      - name: Create Cache Key
-        id: cache-key
-        run: |
-          echo "::set-output name=key::$(/bin/date -u "+%Y%U")"
-        shell: bash
-
       - uses: actions/checkout@v2
 
       # Enable caching of Docker layers
       - uses: satackey/action-docker-layer-caching@v0.0.8
         continue-on-error: true
         with:
-          key: docker-cache-${{ steps.cache-key.outputs.key }}-{hash}
+          key: build-linux-x86_64-docker-cache-{hash}
           restore-keys: |
-            docker-cache-${{ steps.cache-key.outputs.key }}-
+            build-linux-x86_64-docker-cache-
 
       - name: Build docker image
         run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml build
@@ -50,25 +43,18 @@ jobs:
           name: target_x86_64
           path: target/ # or path/to/artifact
 
-  build-aarch64:
+  build-linux-aarch64:
     runs-on: ubuntu-latest
     steps:
-      # http://man7.org/linux/man-pages/man1/date.1.html
-      - name: Create Cache Key
-        id: cache-key
-        run: |
-          echo "::set-output name=key::$(/bin/date -u "+%Y%U")"
-        shell: bash
-
       - uses: actions/checkout@v2
 
       # Enable caching of Docker layers
       - uses: satackey/action-docker-layer-caching@v0.0.8
         continue-on-error: true
         with:
-          key: docker-cache-${{ steps.cache-key.outputs.key }}-{hash}
+          key: build-linux-aarch64-docker-cache-{hash}
           restore-keys: |
-            docker-cache-${{ steps.cache-key.outputs.key }}-
+            build-linux-aarch64-docker-cache-
 
       - name: Build docker image
         run: docker-compose -f docker/docker-compose.centos-7.yaml build

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -11,16 +11,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy-x86_64:
+  deploy-linx-x86_64:
     runs-on: ubuntu-latest
     steps:
-      # http://man7.org/linux/man-pages/man1/date.1.html
-      - name: Create Cache Key
-        id: cache-key
-        run: |
-          echo "::set-output name=key::$(/bin/date -u "+%Y%U")"
-        shell: bash
-
       - uses: s4u/maven-settings-action@v2.2.0
         with:
           servers: |
@@ -36,9 +29,9 @@ jobs:
       - uses: satackey/action-docker-layer-caching@v0.0.8
         continue-on-error: true
         with:
-          key: docker-cache-${{ steps.cache-key.outputs.key }}-{hash}
+          key: deploy-linx-x86_64-docker-cache-{hash}
           restore-keys: |
-            docker-cache-${{ steps.cache-key.outputs.key }}-
+            deploy-linx-x86_64-docker-cache-
 
       - name: Build docker image
         run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml build
@@ -52,16 +45,9 @@ jobs:
           name: target_x86_64
           path: target/ # or path/to/artifact
 
-  deploy-aarch64:
+  deploy-linux-aarch64:
     runs-on: ubuntu-latest
     steps:
-      # http://man7.org/linux/man-pages/man1/date.1.html
-      - name: Create Cache Key
-        id: cache-key
-        run: |
-          echo "::set-output name=key::$(/bin/date -u "+%Y%U")"
-        shell: bash
-
       - uses: s4u/maven-settings-action@v2.2.0
         with:
           servers: |
@@ -77,9 +63,9 @@ jobs:
       - uses: satackey/action-docker-layer-caching@v0.0.8
         continue-on-error: true
         with:
-          key: docker-cache-${{ steps.cache-key.outputs.key }}-{hash}
+          key: deploy-linux-aarch64-docker-cache-{hash}
           restore-keys: |
-            docker-cache-${{ steps.cache-key.outputs.key }}-
+            deploy-linux-aarch64-docker-cache-
 
       - name: Build docker image
         run: docker-compose -f docker/docker-compose.centos-7.yaml build

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -1,9 +1,7 @@
-name: Build project
+name: Deploy snapshots
 
 on:
   push:
-    branches: [ main ]
-  pull_request:
     branches: [ main ]
 
   schedule:
@@ -13,7 +11,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-x86_64:
+  deploy-x86_64:
     runs-on: ubuntu-latest
     steps:
       # http://man7.org/linux/man-pages/man1/date.1.html
@@ -45,16 +43,7 @@ jobs:
       - name: Build docker image
         run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml build
 
-      - name: Build project without leak detection
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml run build
-
-      - name: Build project with leak detection
-        if: ${{ github.event_name == 'pull_request' }}
-        run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml run build-leak
-
       - name: Deploy project snapshot to sonatype
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml run deploy
 
       - uses: actions/upload-artifact@v2
@@ -63,7 +52,7 @@ jobs:
           name: target_x86_64
           path: target/ # or path/to/artifact
 
-  build-aarch64:
+  deploy-aarch64:
     runs-on: ubuntu-latest
     steps:
       # http://man7.org/linux/man-pages/man1/date.1.html
@@ -95,11 +84,7 @@ jobs:
       - name: Build docker image
         run: docker-compose -f docker/docker-compose.centos-7.yaml build
 
-      - name: Build project
-        run: docker-compose -f docker/docker-compose.centos-7.yaml run cross-compile-aarch64-build
-
       - name: Deploy project snapshot to sonatype
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main'}}
         run: docker-compose -f docker/docker-compose.centos-7.yaml run cross-compile-aarch64-deploy
 
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
Motivation:

We should split up work to different workflows as it also make it easier to run the seperatly and also makes it easier to control things

Modifications:

Split build and deploy to different workflows

Result:

Easier to configure jobs