### PR TITLE
Only upload on build failures

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -40,8 +40,8 @@ jobs:
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}
         with:
-          name: target_x86_64
-          path: target/ # or path/to/artifact
+          name: target
+          path: "**/target/"
 
   build-linux-aarch64:
     runs-on: ubuntu-latest
@@ -65,5 +65,5 @@ jobs:
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}
         with:
-          name: target_aarch64
-          path: target/ # or path/to/artifact
+          name: target
+          path: "**/target/"

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -39,12 +39,6 @@ jobs:
       - name: Deploy project snapshot to sonatype
         run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml run deploy
 
-      - uses: actions/upload-artifact@v2
-        if: ${{ failure() }}
-        with:
-          name: target_x86_64
-          path: target/ # or path/to/artifact
-
   deploy-linux-aarch64:
     runs-on: ubuntu-latest
     steps:
@@ -72,9 +66,3 @@ jobs:
 
       - name: Deploy project snapshot to sonatype
         run: docker-compose -f docker/docker-compose.centos-7.yaml run cross-compile-aarch64-deploy
-
-      - uses: actions/upload-artifact@v2
-        if: ${{ failure() }}
-        with:
-          name: target_aarch64
-          path: target/ # or path/to/artifact


### PR DESCRIPTION
Motivation:

We should only upload target directories on build failure

Modifications:

- Only upload on build failure
- Make the matching more future-prove by also working with multi-module projects

Result:

Cleanup