### PR TITLE
Force JNI initialization when IOUringEventLoopGroup is loaded

### DIFF
--- a/src/main/java/io/netty/incubator/channel/uring/IOUringEventLoopGroup.java
+++ b/src/main/java/io/netty/incubator/channel/uring/IOUringEventLoopGroup.java
@@ -29,6 +29,10 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadFactory;
 
 public final class IOUringEventLoopGroup extends MultithreadEventLoopGroup {
+    static {
+        // Ensure JNI is initialized as soon as this class is loaded
+        IOUring.ensureAvailability();
+    }
 
     /**
      * Create a new instance using the default number of threads and the default {@link ThreadFactory}.


### PR DESCRIPTION
Motivation:

We need to ensure we force the JNI initialization when the
IOUringEventLoopGroup is loaded. Otherwise things will fail if we didnt
do it outself.

Modifications:

Call IOUring to force JNI init.

Result:

Fixes https://github.com/netty/netty-incubator-transport-io_uring/issues/47