### PR TITLE
Split pr and normal build

### DIFF
--- a/.github/scripts/check_leak.sh
+++ b/.github/scripts/check_leak.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ "$#" -ne 1 ]; then
+    echo "Expected build log as argument"
+    exit 1
+fi
+
+if grep -q 'LEAK:' $1 ; then
+    echo "Leak detected, please inspect build log"
+    exit 1
+else
+    echo "No Leak detected"
+    exit 0
+fi
+

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,18 +1,37 @@
-name: Build project
+name: Build PR
 
 on:
-  push:
+  pull_request:
     branches: [ main ]
-
-  schedule:
-    - cron: '30 5 * * 1'  # At 05:30 on Monday, every Monday.
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:
+  verify:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      # Cache .m2/repository
+      - uses: actions/cache@v2
+        env:
+          cache-name: verify-cache-m2-repository
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-pr-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-pr-${{ env.cache-name }}-
+            ${{ runner.os }}-pr-
+      - name: Verify with Maven
+        run: mvn verify -B --file pom.xml -DskipTests=true
+
   build-linux-x86_64:
     runs-on: ubuntu-latest
+    needs: verify
     steps:
       - uses: actions/checkout@v2
 
@@ -27,8 +46,11 @@ jobs:
       - name: Build docker image
         run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml build
 
-      - name: Build project without leak detection
-        run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml run build
+      - name: Build project with leak detection
+        run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml run build-leak | tee build-leak.output
+
+      - name: Checking for detected leak
+        run: ./.github/scripts/check_leak.sh build-leak.output
 
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}
@@ -38,6 +60,7 @@ jobs:
 
   build-linux-aarch64:
     runs-on: ubuntu-latest
+    needs: verify
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Motivation:

We should better use seperate workflows for PR and normal builds

Modifications:

- Split workflows
- Better cache reuse

Result:

Cleanup