### PR TITLE
Correctly deploy artifacts that are build on different archs (#10893)

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -11,60 +11,104 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy-linux-x86_64:
+  stage-snapshot:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - setup: linux-x86_64
+            docker-compose-build: "-f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml build"
+            docker-compose-run: "-f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml run stage-snapshot"
+          - setup: linux-aarch64
+            docker-compose-build: "-f docker/docker-compose.centos-7.yaml build"
+            docker-compose-run: "-f docker/docker-compose.centos-7.yaml run cross-compile-aarch64-stage-snapshot"
+    name: stage-snapshot-${{ matrix.setup }}
     steps:
-      - uses: s4u/maven-settings-action@v2.2.0
-        with:
-          servers: |
-            [{
-                "id": "sonatype-nexus-snapshots",
-                "username": "${{ secrets.SONATYPE_USERNAME }}",
-                "password": "${{ secrets.SONATYPE_PASSWORD }}"
-            }]
-
       - uses: actions/checkout@v2
 
       # Enable caching of Docker layers
       - uses: satackey/action-docker-layer-caching@v0.0.8
+        env:
+          docker-cache-name: staging-${{ matrix.setup }}-cache-docker
         continue-on-error: true
         with:
-          key: deploy-linux-x86_64-docker-cache-{hash}
+          key: ${{ runner.os }}-staging-${{ env.docker-cache-name }}-{hash}
           restore-keys: |
-            deploy-linux-x86_64-docker-cache-
+            ${{ runner.os }}-staging-${{ env.docker-cache-name }}-
+
+      - name: Create local staging directory
+        run: mkdir -p ~/local-staging
 
       - name: Build docker image
-        run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml build
+        run: docker-compose ${{ matrix.docker-compose-build }}
 
-      - name: Deploy project snapshot to sonatype
-        run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml run deploy
+      - name: Stage snapshots to local staging directory
+        run: docker-compose ${{ matrix.docker-compose-run }}
 
-  deploy-linux-aarch64:
-    runs-on: ubuntu-latest
-    # Skip for now until we figured out how to deploy SNAPSHOTS with the the same timestamps
-    if: ${{ false }}
+      - name: Upload local staging directory
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.setup }}-local-staging
+          path: ~/local-staging
+
+  deploy-staged-snapshots:
+    runs-on: ubuntu-18.04
+    # Wait until we have staged everything
+    needs: stage-snapshot
     steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+
+      # Cache .m2/repository
+      - uses: actions/cache@v2
+        env:
+          cache-name: deploy-staging-cache-m2-repository
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-deploy-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-deploy-${{ env.cache-name }}-
+            ${{ runner.os }}-deploy-
+
+      # Setup some env to re-use later.
+      - name: Prepare enviroment variables
+        run: |
+          echo "LOCAL_STAGING_DIR=$HOME/local-staging" >> $GITHUB_ENV
+
+      # Hardcode the staging artifacts that need to be downloaded.
+      # These must match the matrix setups. There is currently no way to pull this out of the config.
+      - name: Download linux-aarch64 staging directory
+        uses: actions/download-artifact@v2
+        with:
+          name: linux-aarch64-local-staging
+          path: ~/linux-aarch64-local-staging
+
+      - name: Download linux-x86_64 staging directory
+        uses: actions/download-artifact@v2
+        with:
+          name: linux-x86_64-local-staging
+          path: ~/linux-x86_64-local-staging
+
+      - name: Merge staging repositories
+        run: |
+          mkdir -p ~/local-staging/deferred
+          cat ~/linux-aarch64-local-staging/deferred/.index >>  ~/local-staging/deferred/.index
+          cp -r ~/linux-aarch64-local-staging/deferred/* ~/local-staging/deferred/
+          cat ~/linux-x86_64-local-staging/deferred/.index >>  ~/local-staging/deferred/.index
+          cp -r ~/linux-x86_64-local-staging/deferred/* ~/local-staging/deferred/
+
       - uses: s4u/maven-settings-action@v2.2.0
         with:
           servers: |
             [{
-                "id": "sonatype-nexus-snapshots",
-                "username": "${{ secrets.SONATYPE_USERNAME }}",
-                "password": "${{ secrets.SONATYPE_PASSWORD }}"
+              "id": "sonatype-nexus-snapshots",
+              "username": "${{ secrets.SONATYPE_USERNAME }}",
+              "password": "${{ secrets.SONATYPE_PASSWORD }}"
             }]
 
-      - uses: actions/checkout@v2
-
-      # Enable caching of Docker layers
-      - uses: satackey/action-docker-layer-caching@v0.0.8
-        continue-on-error: true
-        with:
-          key: deploy-linux-aarch64-docker-cache-{hash}
-          restore-keys: |
-            deploy-linux-aarch64-docker-cache-
-
-      - name: Build docker image
-        run: docker-compose -f docker/docker-compose.centos-7.yaml build
-
-      - name: Deploy project snapshot to sonatype
-        run: docker-compose -f docker/docker-compose.centos-7.yaml run cross-compile-aarch64-deploy
+      - name: Deploy local staged artifacts
+        run: mvn -B --file pom.xml org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DaltStagingDirectory=$LOCAL_STAGING_DIR

--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -17,5 +17,8 @@ services:
   deploy:
     image: netty-io_uring:centos-6-1.8
 
+  stage-snapshot:
+    image: netty-io_uring:centos-6-1.8
+
   shell:
     image: netty-io_uring:centos-6-1.8

--- a/docker/docker-compose.centos-6.yaml
+++ b/docker/docker-compose.centos-6.yaml
@@ -34,6 +34,16 @@ services:
       - ~/.m2/settings.xml:/root/.m2/settings.xml
       - ..:/code
 
+  stage-snapshot:
+    <<: *common
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - ~/.gnupg:/root/.gnupg
+      - ~/.m2:/root/.m2
+      - ~/local-staging:/root/local-staging
+      - ..:/code
+    command: /bin/bash -cl "./mvnw clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
+
   shell:
     <<: *common
     environment:

--- a/docker/docker-compose.centos-7.yaml
+++ b/docker/docker-compose.centos-7.yaml
@@ -29,6 +29,17 @@ services:
       - ~/.m2/settings.xml:/root/.m2/settings.xml
       - ..:/code
 
+  cross-compile-aarch64-stage-snapshot:
+    <<: *cross-compile-aarch64-common
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - ~/.gnupg:/root/.gnupg
+      - ~/.m2:/root/.m2
+      - ~/local-staging:/root/local-staging
+      - ..:/code
+    command: /bin/bash -cl "./mvnw -Plinux-aarch64 clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
+
+
   cross-compile-aarch64-shell:
     <<: *cross-compile-aarch64-common
     volumes:


### PR DESCRIPTION
Motivation:

We need to take special care when deploying snapshots as we need to generate the jars in multiple steps

Modifications:

- Use the nexus staging pluging to stage jars locally in multiple steps
- Add extra job that will merge these staged jars and deploy these

Result:

Correctly deploy for all archs