### PR TITLE
Update action-docker-layer-caching

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v2
 
       # Enable caching of Docker layers
-      - uses: satackey/action-docker-layer-caching@v0.0.8
+      - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true
         with:
           key: build-${{ matrix.setup }}-docker-cache-{hash}

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v2
 
       # Enable caching of Docker layers
-      - uses: satackey/action-docker-layer-caching@v0.0.8
+      - uses: satackey/action-docker-layer-caching@v0.0.11
         env:
           docker-cache-name: staging-${{ matrix.setup }}-cache-docker
         continue-on-error: true

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v2
 
       # Enable caching of Docker layers
-      - uses: satackey/action-docker-layer-caching@v0.0.8
+      - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true
         with:
           key: pr-${{ matrix.setup }}-docker-cache-{hash}


### PR DESCRIPTION
Motivation:

We are three releases behind.

Modifications:

Update to latest version

Result:

Use up-to-date action-docker-layer-caching version