### PR TITLE
Update to netty 4.1.47.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
 
     <checkstyle.version>8.38</checkstyle.version>
     <junit.version>4.13.1</junit.version>
-    <netty.version>4.1.57.Final-SNAPSHOT</netty.version>
+    <netty.version>4.1.57.Final</netty.version>
     <netty-tcnative-boringssl-static.version>2.0.35.Final</netty-tcnative-boringssl-static.version>
 
     <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>


### PR DESCRIPTION
Motivation:

4.1.47.Final is out, we should replace our SNAPSHOT dependency

Modifications:

Update to non SNAPSHOT release

Result:

Don't depend on SNAPSHOT