### PR TITLE
Make use of Unix.registerInternal(...) to register native methods of t…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
 
     <checkstyle.version>8.38</checkstyle.version>
     <junit.version>4.13.1</junit.version>
-    <netty.version>4.1.58.Final</netty.version>
+    <netty.version>4.1.59.Final-SNAPSHOT</netty.version>
     <netty-tcnative-boringssl-static.version>2.0.35.Final</netty-tcnative-boringssl-static.version>
 
     <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>

--- a/src/main/c/netty_io_uring.h
+++ b/src/main/c/netty_io_uring.h
@@ -24,6 +24,7 @@
 #include "netty_unix_limits.h"
 #include "netty_unix_socket.h"
 #include "netty_unix_util.h"
+#include "netty_unix.h"
 
 #ifndef NETTY_IO_URING
 #define NETTY_IO_URING

--- a/src/main/java/io/netty/incubator/channel/uring/Native.java
+++ b/src/main/java/io/netty/incubator/channel/uring/Native.java
@@ -16,7 +16,7 @@
 package io.netty.incubator.channel.uring;
 
 import io.netty.channel.unix.FileDescriptor;
-import io.netty.channel.unix.Socket;
+import io.netty.channel.unix.Unix;
 import io.netty.util.internal.NativeLibraryLoader;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SystemPropertyUtil;
@@ -62,7 +62,12 @@ final class Native {
                 // Just ignore
             }
         }
-        Socket.initialize();
+        Unix.registerInternal(new Runnable() {
+            @Override
+            public void run() {
+                registerUnix();
+            }
+        });
     }
     static final int SOCK_NONBLOCK = NativeStaticallyReferencedJniMethods.sockNonblock();
     static final int SOCK_CLOEXEC = NativeStaticallyReferencedJniMethods.sockCloexec();
@@ -201,6 +206,8 @@ final class Native {
 
     // for testing(it is only temporary)
     public static native int createFile();
+
+    private static native int registerUnix();
 
     private Native() {
         // utility


### PR DESCRIPTION
…he unix module

Motivation:

We need to ensure we only register the methods for unix-native-common once as otherwise it may have strange side-effects.

Modifications:

- Update to snapshot that expose the required method / functions
- Adjust code

Result:

Be able to have different native transports on the classpath without problems 