### PR TITLE
Add check isTraceEnabled for avoid unnecessary object allocation

### DIFF
--- a/src/main/java/io/netty/incubator/channel/uring/IOUringSubmissionQueue.java
+++ b/src/main/java/io/netty/incubator/channel/uring/IOUringSubmissionQueue.java
@@ -142,10 +142,12 @@ final class IOUringSubmissionQueue {
         long userData = encode(fd, op, data);
         PlatformDependent.putLong(sqe + SQE_USER_DATA_FIELD, userData);
 
-        logger.trace("UserDataField: {}", userData);
-        logger.trace("BufferAddress: {}", bufferAddress);
-        logger.trace("Length: {}", length);
-        logger.trace("Offset: {}", offset);
+        if (logger.isTraceEnabled()) {
+            logger.trace("UserDataField: {}", userData);
+            logger.trace("BufferAddress: {}", bufferAddress);
+            logger.trace("Length: {}", length);
+            logger.trace("Offset: {}", offset);
+        }
     }
 
     boolean addTimeout(long nanoSeconds, short extraData) {


### PR DESCRIPTION
Motivation:

The `InternalLogger.trace()` uses a formatted `String` and `Object` as an arguments, so if we pass a primitive type (e.g. int) it will be autoboxed to `java.lang.Integer`.

Modifications:

Add additional check `isTraceEnabled` before call logger to avoid unnecessary allocation. 

Result:

Fixes: #61
