### PR TITLE
Use custom script to check for build failures

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -107,10 +107,8 @@ jobs:
       - name: Build project via QEMU
         run: expect -f ./.github/scripts/qemu_build.exp /home/runner/.qemu my-disk.qcow2 my-seed.iso | tee build.output
 
-      - name: build-pr-qemu test-report
-        uses: scacap/action-surefire-report@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checking for test failures
+        run: ./.github/scripts/check_build_result.sh build.output
 
       - name: Checking for detected leak
         run: bash ./.github/scripts/check_leak.sh build.output


### PR DESCRIPTION
Motivation:

It turns out we can't use the action to check for build failures as it can't be used when a PR is done from a fork. Let's just use our simple script.

Modifications:

- Replace action with custom script

Result:

Builds for PRs that are done via forks work again.