### PR TITLE
Publish test results after PR run

### DIFF
--- a/.github/workflows/ci-pr-reports.yml
+++ b/.github/workflows/ci-pr-reports.yml
@@ -1,0 +1,25 @@
+name: PR Reports
+on:
+  workflow_run:
+    workflows: [ "Build PR" ]
+    types:
+      - completed
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Artifacts
+        uses: dawidd6/action-download-artifact@v2.11.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          commit: ${{ github.event.workflow_run.head_commit.id }}
+          # File location set in ci-pr.yml and must be coordinated.
+          name: test-results-build-pr-qemu
+      - name: Publish Test Report
+        uses: scacap/action-surefire-report@v1.0.7
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          report_paths: '**/target/surefire-reports/TEST-*.xml'
+          commit: ${{ github.event.workflow_run.head_commit.id }}
+          check_name: test reports

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -113,6 +113,13 @@ jobs:
       - name: Checking for detected leak
         run: bash ./.github/scripts/check_leak.sh build.output
 
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-results-build-pr-qemu
+          path: '**/target/surefire-reports/TEST-*.xml'
+
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}
         with:


### PR DESCRIPTION
Motivation:

To make it easier to understand why a build failed let us publish the rest results

Modifications:

Use a new workflow to be able to publish the test reports

Result:

Easier to understand why a PR did fail