### PR TITLE
Update to latest netty version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
 
     <checkstyle.version>8.38</checkstyle.version>
     <junit.version>4.13.1</junit.version>
-    <netty.version>4.1.59.Final-SNAPSHOT</netty.version>
+    <netty.version>4.1.59.Final</netty.version>
     <netty-tcnative-boringssl-static.version>2.0.36.Final</netty-tcnative-boringssl-static.version>
 
     <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>


### PR DESCRIPTION
Motivation:

A new netty version was released, we can remove our SNAPSHOT dependency.

Modifications:

Update to 4.1.59.Final

Result:

Don't depend on a snapshot version