### PR TITLE
Fixes #76 - Make it possible to pass flags to io_uring_setup()

### DIFF
--- a/src/main/c/netty_io_uring_native.c
+++ b/src/main/c/netty_io_uring_native.c
@@ -221,9 +221,10 @@ done:
 }
 
 
-static jobjectArray netty_io_uring_setup(JNIEnv *env, jclass clazz, jint entries) {
+static jobjectArray netty_io_uring_setup(JNIEnv *env, jclass clazz, jint entries, jint flags) {
     struct io_uring_params p;
     memset(&p, 0, sizeof(p));
+    p.flags = flags;
 
     jobjectArray array = (*env)->NewObjectArray(env, 2, longArrayClass, NULL);
     if (array == NULL) {
@@ -539,7 +540,7 @@ static const JNINativeMethod statically_referenced_fixed_method_table[] = {
 static const jint statically_referenced_fixed_method_table_size = sizeof(statically_referenced_fixed_method_table) / sizeof(statically_referenced_fixed_method_table[0]);
 
 static const JNINativeMethod method_table[] = {
-    {"ioUringSetup", "(I)[[J", (void *) netty_io_uring_setup},
+    {"ioUringSetup", "(II)[[J", (void *) netty_io_uring_setup},
     {"ioUringProbe", "(I[I)Z", (void *) netty_io_uring_probe},
     {"ioUringExit", "(JIJIJII)V", (void *) netty_io_uring_ring_buffer_exit},
     {"createFile", "()I", (void *) netty_create_file},

--- a/src/main/java/io/netty/incubator/channel/uring/IOUringEventLoop.java
+++ b/src/main/java/io/netty/incubator/channel/uring/IOUringEventLoop.java
@@ -57,14 +57,14 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements IOUringCom
     private long prevDeadlineNanos = NONE;
     private boolean pendingWakeup;
 
-    IOUringEventLoop(IOUringEventLoopGroup parent, Executor executor, int ringSize, int iosqeAsyncThreshold,
+    IOUringEventLoop(IOUringEventLoopGroup parent, Executor executor, int ringSize, int iosqeAsyncThreshold, int flags,
                      RejectedExecutionHandler rejectedExecutionHandler, EventLoopTaskQueueFactory queueFactory) {
         super(parent, executor, false, newTaskQueue(queueFactory), newTaskQueue(queueFactory),
                 rejectedExecutionHandler);
         // Ensure that we load all native bits as otherwise it may fail when try to use native methods in IovArray
         IOUring.ensureAvailability();
 
-        ringBuffer = Native.createRingBuffer(ringSize, iosqeAsyncThreshold);
+        ringBuffer = Native.createRingBuffer(ringSize, iosqeAsyncThreshold, flags);
 
         eventfd = Native.newBlockingEventFd();
         logger.trace("New EventLoop: {}", this.toString());

--- a/src/main/java/io/netty/incubator/channel/uring/Native.java
+++ b/src/main/java/io/netty/incubator/channel/uring/Native.java
@@ -34,6 +34,7 @@ final class Native {
     static final int DEFAULT_RING_SIZE = Math.max(64, SystemPropertyUtil.getInt("io.netty.uring.ringSize", 4096));
     static final int DEFAULT_IOSEQ_ASYNC_THRESHOLD =
             Math.max(0, SystemPropertyUtil.getInt("io.netty.uring.iosqeAsyncThreshold", 25));
+    static final int DEFAULT_RING_FLAGS = Math.max(0, SystemPropertyUtil.getInt("io.netty.uring.ringFlags", 0));
 
     static {
         Selector selector = null;
@@ -139,11 +140,11 @@ final class Native {
     };
 
     static RingBuffer createRingBuffer(int ringSize) {
-        return createRingBuffer(ringSize, DEFAULT_IOSEQ_ASYNC_THRESHOLD);
+        return createRingBuffer(ringSize, DEFAULT_IOSEQ_ASYNC_THRESHOLD, DEFAULT_RING_FLAGS);
     }
 
-    static RingBuffer createRingBuffer(int ringSize, int iosqeAsyncThreshold) {
-        long[][] values = ioUringSetup(ringSize);
+    static RingBuffer createRingBuffer(int ringSize, int iosqeAsyncThreshold, int flags) {
+        long[][] values = ioUringSetup(ringSize, flags);
         assert values.length == 2;
         long[] submissionQueueArgs = values[0];
         assert submissionQueueArgs.length == 11;
@@ -176,7 +177,7 @@ final class Native {
     }
 
     static RingBuffer createRingBuffer() {
-        return createRingBuffer(DEFAULT_RING_SIZE, DEFAULT_IOSEQ_ASYNC_THRESHOLD);
+        return createRingBuffer(DEFAULT_RING_SIZE, DEFAULT_IOSEQ_ASYNC_THRESHOLD, DEFAULT_RING_FLAGS);
     }
 
     static void checkAllIOSupported(int ringFd) {
@@ -187,7 +188,7 @@ final class Native {
     }
 
     private static native boolean ioUringProbe(int ringFd, int[] ios);
-    private static native long[][] ioUringSetup(int entries);
+    private static native long[][] ioUringSetup(int entries, int flags);
 
     public static native int ioUringEnter(int ringFd, int toSubmit, int minComplete, int flags);
 

--- a/src/test/java/io/netty/incubator/channel/uring/NativeTest.java
+++ b/src/test/java/io/netty/incubator/channel/uring/NativeTest.java
@@ -19,7 +19,7 @@ import io.netty.channel.unix.FileDescriptor;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -43,7 +43,7 @@ public class NativeTest {
         ByteBufAllocator allocator = new UnpooledByteBufAllocator(true);
         final ByteBuf writeEventByteBuf = allocator.directBuffer(100);
         final String inputString = "Hello World!";
-        writeEventByteBuf.writeCharSequence(inputString, Charset.forName("UTF-8"));
+        writeEventByteBuf.writeCharSequence(inputString, StandardCharsets.UTF_8);
 
         int fd = Native.createFile();
 


### PR DESCRIPTION
Motivation:
It should be possible the user application to pass IO_SETUP_** flags (https://manpages.debian.org/unstable/liburing-dev/io_uring_setup.2.en.html)

Modifications:
Add 'int flags' argument to io_uring_setup() call and in the respective Java APIs

Result:
io_uring_params.flags could be initialized before the call to io_uring_setup()