### PR TITLE
Use MSG_DONTWAIT to workaround io_uring bug with datagrams

### DIFF
--- a/src/main/c/netty_io_uring_native.c
+++ b/src/main/c/netty_io_uring_native.c
@@ -485,6 +485,11 @@ static jint netty_io_uring_iosqeAsync(JNIEnv* env, jclass clazz) {
     return IOSQE_ASYNC;
 }
 
+static jint netty_io_uring_msgDontwait(JNIEnv* env, jclass clazz) {
+    return MSG_DONTWAIT;
+}
+
+
 
 // JNI Method Registration Table Begin
 static const JNINativeMethod statically_referenced_fixed_method_table[] = {
@@ -534,7 +539,8 @@ static const JNINativeMethod statically_referenced_fixed_method_table[] = {
   { "ioringOpSendmsg", "()B", (void *) netty_io_uring_ioringOpSendmsg },
   { "ioringOpRecvmsg", "()B", (void *) netty_io_uring_ioringOpRecvmsg },
   { "ioringEnterGetevents", "()I", (void *) netty_io_uring_ioringEnterGetevents },
-  { "iosqeAsync", "()I", (void *) netty_io_uring_iosqeAsync }
+  { "iosqeAsync", "()I", (void *) netty_io_uring_iosqeAsync },
+  { "msgDontwait", "()I", (void *) netty_io_uring_msgDontwait }
 };
 static const jint statically_referenced_fixed_method_table_size = sizeof(statically_referenced_fixed_method_table) / sizeof(statically_referenced_fixed_method_table[0]);
 

--- a/src/main/java/io/netty/incubator/channel/uring/IOUringSubmissionQueue.java
+++ b/src/main/java/io/netty/incubator/channel/uring/IOUringSubmissionQueue.java
@@ -172,11 +172,15 @@ final class IOUringSubmissionQueue {
     }
 
     boolean addRecvmsg(int fd, long msgHdr, short extraData) {
-        return enqueueSqe(Native.IORING_OP_RECVMSG, flags(), 0, fd, msgHdr, 1, 0, extraData);
+        // Use Native.MSG_DONTWAIT due a io_uring bug which did have it not respect non-blocking fds.
+        // See https://lore.kernel.org/io-uring/371592A7-A199-4F5C-A906-226FFC6CEED9@googlemail.com/T/#u
+        return enqueueSqe(Native.IORING_OP_RECVMSG, flags(), Native.MSG_DONTWAIT, fd, msgHdr, 1, 0, extraData);
     }
 
     boolean addSendmsg(int fd, long msgHdr, short extraData) {
-        return enqueueSqe(Native.IORING_OP_SENDMSG, flags(), 0, fd, msgHdr, 1, 0, extraData);
+        // Use Native.MSG_DONTWAIT due a io_uring bug which did have it not respect non-blocking fds.
+        // see https://lore.kernel.org/io-uring/371592A7-A199-4F5C-A906-226FFC6CEED9@googlemail.com/T/#u
+        return enqueueSqe(Native.IORING_OP_SENDMSG, flags(), Native.MSG_DONTWAIT, fd, msgHdr, 1, 0, extraData);
     }
 
     boolean addRead(int fd, long bufferAddress, int pos, int limit, short extraData) {

--- a/src/main/java/io/netty/incubator/channel/uring/Native.java
+++ b/src/main/java/io/netty/incubator/channel/uring/Native.java
@@ -123,6 +123,7 @@ final class Native {
     static final byte IORING_OP_RECVMSG = NativeStaticallyReferencedJniMethods.ioringOpRecvmsg();
     static final int IORING_ENTER_GETEVENTS = NativeStaticallyReferencedJniMethods.ioringEnterGetevents();
     static final int IOSQE_ASYNC = NativeStaticallyReferencedJniMethods.iosqeAsync();
+    static final int MSG_DONTWAIT = NativeStaticallyReferencedJniMethods.msgDontwait();
 
     private static final int[] REQUIRED_IORING_OPS = {
             IORING_OP_POLL_ADD,

--- a/src/main/java/io/netty/incubator/channel/uring/NativeStaticallyReferencedJniMethods.java
+++ b/src/main/java/io/netty/incubator/channel/uring/NativeStaticallyReferencedJniMethods.java
@@ -77,4 +77,5 @@ final class NativeStaticallyReferencedJniMethods {
     static native byte ioringOpRecvmsg();
     static native int ioringEnterGetevents();
     static native int iosqeAsync();
+    static native int msgDontwait();
 }

--- a/src/test/java/io/netty/incubator/channel/uring/IOUringDatagramUnicastTest.java
+++ b/src/test/java/io/netty/incubator/channel/uring/IOUringDatagramUnicastTest.java
@@ -16,12 +16,33 @@
 package io.netty.incubator.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.FixedRecvByteBufAllocator;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.socket.DatagramPacket;
 import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.DatagramUnicastTest;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.ReferenceCounted;
+import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assume.assumeTrue;
 
@@ -35,5 +56,52 @@ public class IOUringDatagramUnicastTest extends DatagramUnicastTest {
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<Bootstrap, Bootstrap>> newFactories() {
         return IOUringSocketTestPermutation.INSTANCE.datagram(InternetProtocolFamily.IPv4);
+    }
+
+    @Test(timeout = 8000)
+    public void testRecvMsgDontBlock() throws Throwable {
+        run();
+    }
+
+    public void testRecvMsgDontBlock(Bootstrap sb, Bootstrap cb) throws Throwable {
+        Channel sc = null;
+        Channel cc = null;
+
+        try {
+            cb.handler(new SimpleChannelInboundHandler<Object>() {
+                public void channelRead0(ChannelHandlerContext ctx, Object msgs) {
+                    // NOOP.
+                }
+            });
+            cc = cb.bind(newSocketAddress()).sync().channel();
+
+            CountDownLatch readLatch = new CountDownLatch(1);
+            CountDownLatch readCompleteLatch = new CountDownLatch(1);
+            sc = sb.handler(new ChannelInboundHandlerAdapter() {
+                @Override
+                public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                    readLatch.countDown();
+                    ReferenceCountUtil.release(msg);
+                }
+
+                @Override
+                public void channelReadComplete(ChannelHandlerContext ctx) {
+                    readCompleteLatch.countDown();
+                }
+            }).option(ChannelOption.RCVBUF_ALLOCATOR, new FixedRecvByteBufAllocator(2048))
+                    .option(ChannelOption.MAX_MESSAGES_PER_READ, 2).bind(newSocketAddress()).sync().channel();
+            InetSocketAddress addr = sendToAddress((InetSocketAddress) sc.localAddress());
+            cc.writeAndFlush(new DatagramPacket(Unpooled.directBuffer().writeZero(512), addr)).sync();
+
+            readLatch.await();
+            readCompleteLatch.await();
+        } finally {
+            if (cc != null) {
+                cc.close().sync();
+            }
+            if (sc != null) {
+                sc.close().sync();
+            }
+        }
     }
 }


### PR DESCRIPTION
Motivation:

io_uring has a bug which lead to the situation that it not correctly
respect the non-blocking nature of a fd and so may block on recvmsg
forever.

Modifications:

- Workaround said bug by using MSG_DONTWAIT
- Correctly continue reading until we shouldnt
- Add unit test

Result:

io_uring works for DatagramChannels as expected