### PR TITLE
Github Actions dawidd6/action-download-artifact set workflow_conclusi…

### DIFF
--- a/.github/workflows/ci-pr-reports.yml
+++ b/.github/workflows/ci-pr-reports.yml
@@ -9,10 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download Artifacts
-        uses: dawidd6/action-download-artifact@v2.11.0
+        uses: dawidd6/action-download-artifact@v2.13.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: ${{ github.event.workflow_run.workflow_id }}
+          workflow_conclusion: completed
           commit: ${{ github.event.workflow_run.head_commit.id }}
           # File location set in ci-pr.yml and must be coordinated.
           name: test-results-build-pr-qemu


### PR DESCRIPTION
…on and upgrade

Motivation:

Newer versions of dawidd6/action-download-artifact changed the default
workflow_conclusion from "completed" to "completed, success" which can
result in download failures if the associated job fails, which is
expected when tests fail.

Modifications:

- Explicitly set the workflow_conclusion to "completed"
- Update to new version

Result:

Test failures which result in build failures will still download test
data and generate reports after updating dawidd6/action-download-artifact.