### PR TITLE
Let's use gcc10 when cross-compiling for LSE support

### DIFF
--- a/docker/Dockerfile.centos7
+++ b/docker/Dockerfile.centos7
@@ -33,7 +33,7 @@ WORKDIR /opt
 
 # Install aarch64 gcc 10.2 toolchain
 RUN wget https://developer.arm.com/-/media/Files/downloads/gnu-a/$GCC_VERSION/binrel/gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu.tar.xz && \
-   tar xvf gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu.tar.xz && mv gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu /opt/
+   tar xvf gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu.tar.xz
 ENV PATH="/opt/gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu/bin:${PATH}"
 
 # Install maven

--- a/docker/Dockerfile.centos7
+++ b/docker/Dockerfile.centos7
@@ -1,6 +1,6 @@
 FROM centos:7.9.2009
 
-ARG gcc_version=4.9-2016.02
+ARG gcc_version=10.2-2020.11
 ENV GCC_VERSION $gcc_version
 
 ENV SOURCE_DIR /root/source
@@ -31,9 +31,10 @@ RUN echo 'PATH=/jdk/bin:$PATH' >> ~/.bashrc
 
 WORKDIR /opt
 
-# Install aarch64 gcc toolchain
-RUN wget -qO- https://releases.linaro.org/components/toolchain/binaries/$GCC_VERSION/aarch64-linux-gnu/gcc-linaro-$GCC_VERSION-x86_64_aarch64-linux-gnu.tar.xz | tar -xvJ
-RUN echo 'export PATH=/opt/gcc-linaro-$GCC_VERSION-x86_64_aarch64-linux-gnu/bin:$PATH' >> ~/.bashrc
+# Install aarch64 gcc 10.2 toolchain
+RUN wget https://developer.arm.com/-/media/Files/downloads/gnu-a/$GCC_VERSION/binrel/gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu.tar.xz && \
+   tar xvf gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu.tar.xz && mv gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu /opt/
+ENV PATH="/opt/gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu/bin:${PATH}"
 
 # Install maven
 RUN curl https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | tar -xz

--- a/docker/docker-compose.centos-7.yaml
+++ b/docker/docker-compose.centos-7.yaml
@@ -8,7 +8,7 @@ services:
       context: ../
       dockerfile: docker/Dockerfile.centos7
       args:
-        gcc_version: "4.9-2016.02"
+        gcc_version: "10.2-2020.11"
         java_version: "adopt@1.8.0-272"
 
   cross-compile-aarch64-common: &cross-compile-aarch64-common

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,7 @@
     <jniLibName>netty_transport_native_io_uring_${jniArch}</jniLibName>
     <nativeLibOnlyDir>${project.build.directory}/native-lib-only</nativeLibOnlyDir>
     <extraConfigureArg />
+    <extraConfigureArg2 />
     <test.argLine>-D_</test.argLine>
 
     <checkstyle.version>8.38</checkstyle.version>
@@ -487,6 +488,7 @@
                     <arg>${jni.compiler.args.cflags}</arg>
                     <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
                     <configureArg>${extraConfigureArg}</configureArg>
+                    <configureArg>${extraConfigureArg2}</configureArg>
                   </configureArgs>
                 </configuration>
                 <goals>
@@ -548,6 +550,7 @@
         <!-- As we cross-compile just skip the tests because we could not load this lib on the system anyway -->
         <skipTests>true</skipTests>
         <extraConfigureArg>--host=aarch64-linux-gnu</extraConfigureArg>
+        <extraConfigureArg2>CC=aarch64-none-linux-gnu-gcc</extraConfigureArg2>
       </properties>
     </profile>
     <profile>


### PR DESCRIPTION
Motivation:

LSE (https://mysqlonarm.github.io/ARM-LSE-and-MySQL/) can have a huge performance difference. Let's ensure we use a compiler that can support it.

Modifications:

Update to gcc10 when cross-compiling as it supports LSE and enables it by default

Result:

More optized builds for aarch64