### PR TITLE
Update to netty 4.1.61.Final and netty-tcnative-boringssl-static 2.0.…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,8 +86,8 @@
 
     <checkstyle.version>8.38</checkstyle.version>
     <junit.version>4.13.1</junit.version>
-    <netty.version>4.1.60.Final</netty.version>
-    <netty-tcnative-boringssl-static.version>2.0.36.Final</netty-tcnative-boringssl-static.version>
+    <netty.version>4.1.61.Final</netty.version>
+    <netty-tcnative-boringssl-static.version>2.0.38.Final</netty-tcnative-boringssl-static.version>
 
     <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
     <maven-bundle-plugin.version>5.1.1</maven-bundle-plugin.version>

--- a/src/main/c/netty_io_uring_native.c
+++ b/src/main/c/netty_io_uring_native.c
@@ -659,7 +659,7 @@ done:
     return ret;
 }
 
-static void netty_iouring_native_JNI_OnUnload(JNIEnv* env, const char* packagePrefix) {
+static void netty_iouring_native_JNI_OnUnload(JNIEnv* env) {
     netty_jni_util_unregister_natives(env, staticPackagePrefix, NATIVE_CLASSNAME);
     netty_jni_util_unregister_natives(env, staticPackagePrefix, STATICALLY_CLASSNAME);
     netty_io_uring_native_JNI_OnUnLoad(env, staticPackagePrefix);


### PR DESCRIPTION
…38.Final

Motivation:

A new netty and netty-tcnative version was released. Let's update

Modifications:

- Update to netty 4.1.61.Final
- Update to netty-tcnative-boringssl-static 2.0.38.Final

Result:

Use latest netty / netty-tcnative version