### PR TITLE
Upgrade to netty 4.1.62.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
 
     <checkstyle.version>8.38</checkstyle.version>
     <junit.version>4.13.1</junit.version>
-    <netty.version>4.1.61.Final</netty.version>
+    <netty.version>4.1.62.Final</netty.version>
     <netty-tcnative-boringssl-static.version>2.0.38.Final</netty-tcnative-boringssl-static.version>
 
     <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>


### PR DESCRIPTION
Motivation:

New netty release is out

Modifications:

Upgrade to 4.1.62.Final

Result:

Use latest netty release