### PR TITLE
Use maven dependency caching

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -27,6 +27,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # Cache .m2/repository
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: build-${{ matrix.setup }}-cache-m2-repository-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            build-${{ matrix.setup }}-cache-m2-repository-
+
       # Enable caching of Docker layers
       - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -26,6 +26,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # Cache .m2/repository
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: stage-snapshot-${{ matrix.setup }}-cache-m2-repository-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            stage-snapshot-${{ matrix.setup }}-cache-m2-repository-
+
       # Enable caching of Docker layers
       - uses: satackey/action-docker-layer-caching@v0.0.11
         env:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -46,6 +46,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # Cache .m2/repository
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: build-pr-${{ matrix.setup }}-cache-m2-repository-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            build-pr-${{ matrix.setup }}-cache-m2-repository-
+
       # Enable caching of Docker layers
       - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true

--- a/docker/docker-compose.centos-6.yaml
+++ b/docker/docker-compose.centos-6.yaml
@@ -13,6 +13,7 @@ services:
     depends_on: [runtime-setup]
     volumes:
       - ~/.ssh:/root/.ssh:delegated
+      - ~/.m2/repository:/root/.m2/repository
       - ..:/code:delegated
     working_dir: /code
 

--- a/docker/docker-compose.centos-7.yaml
+++ b/docker/docker-compose.centos-7.yaml
@@ -16,6 +16,7 @@ services:
     image: netty-io_uring:cross_compile_aarch64
     volumes:
       - ~/.ssh:/root/.ssh:delegated
+      - ~/.m2/repository:/root/.m2/repository
       - ..:/code:delegated
     working_dir: /code
 
@@ -25,6 +26,7 @@ services:
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg
+      - ~/.m2/repository:/root/.m2/repository
       - ~/.m2/settings.xml:/root/.m2/settings.xml
       - ..:/code
 


### PR DESCRIPTION
Motivation:

To reduce the likelyness of build failures due network problems it is best to cache maven dependencies.

Modifications:

- Correctly mount .m2/repository
- Use action for caching

Result:

More stable builds