### PR TITLE
Preload classes before calling native OnLoad function to prevent class loader deadlock

### DIFF
--- a/src/main/java/io/netty/incubator/channel/uring/Native.java
+++ b/src/main/java/io/netty/incubator/channel/uring/Native.java
@@ -16,7 +16,9 @@
 package io.netty.incubator.channel.uring;
 
 import io.netty.channel.unix.FileDescriptor;
+import io.netty.channel.unix.PeerCredentials;
 import io.netty.channel.unix.Unix;
+import io.netty.util.internal.ClassInitializerUtil;
 import io.netty.util.internal.NativeLibraryLoader;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SystemPropertyUtil;
@@ -25,6 +27,7 @@ import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.io.IOException;
+import java.nio.channels.FileChannel;
 import java.nio.channels.Selector;
 import java.util.Arrays;
 import java.util.Locale;
@@ -46,6 +49,17 @@ final class Native {
         } catch (IOException ignore) {
             // Just ignore
         }
+
+        // Preload all classes that will be used in the OnLoad(...) function of JNI to eliminate the possiblity of a
+        // class-loader deadlock. This is a workaround for https://github.com/netty/netty/issues/11209.
+
+        // This needs to match all the classes that are loaded via NETTY_JNI_UTIL_LOAD_CLASS or looked up via
+        // NETTY_JNI_UTIL_FIND_CLASS.
+        ClassInitializerUtil.tryLoadClasses(Native.class,
+                // netty_io_uring_linuxsocket
+                PeerCredentials.class, java.io.FileDescriptor.class
+        );
+
         try {
             // First, try calling a side-effect free JNI method to see if the library was already
             // loaded by the application.


### PR DESCRIPTION


Motivation:

It turns out it is quite easy to cause a classloader deadlock in more recent java updates if you cause classloading while you are in native code. Because of this we should just workaround this issue by pre-load all the classes that needs to be accessed in the OnLoad function.

Modifications:

- Preload all classes that would otherwise be loaded by native OnLoad functions.

Result:

Workaround for https://github.com/netty/netty/issues/11209 and https://bugs.openjdk.java.net/browse/JDK-8266310