### PR TITLE
Make build log output less chatty

### DIFF
--- a/.github/scripts/qemu_build.exp
+++ b/.github/scripts/qemu_build.exp
@@ -46,7 +46,7 @@ expect $rootConsole
 send "cd /mnt/\r"
 
 expect $rootConsole
-send "JAVA_HOME=/usr/lib/jvm/java-11 ./mvnw clean package -Dio.netty.testsuite.badHost=netty.io\r"
+send "JAVA_HOME=/usr/lib/jvm/java-11 ./mvnw -B -ntp clean package -Dio.netty.testsuite.badHost=netty.io\r"
 
 # Let's give the build 1 hour before we timeout
 expect -timeout 3600 $rootConsole

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -131,4 +131,4 @@ jobs:
             }]
 
       - name: Deploy local staged artifacts
-        run: mvn -B --file pom.xml org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DaltStagingDirectory=$LOCAL_STAGING_DIR
+        run: mvn -B -ntp  --file pom.xml org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DaltStagingDirectory=$LOCAL_STAGING_DIR

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -42,7 +42,7 @@ jobs:
             ${{ runner.os }}-pr-${{ env.cache-name }}-
             ${{ runner.os }}-pr-
       - name: Verify with Maven
-        run: mvn verify -B --file pom.xml -DskipTests=true
+        run: mvn -B -ntp --file pom.xml verify -DskipTests=true
 
   build-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -56,8 +56,8 @@ jobs:
 
       - name: Prepare release with Maven
         run: |
-          mvn -DpreparationGoals=clean release:prepare -B --file pom.xml -DskipTests=true
-          mvn clean
+          mvn -B -ntp --file pom.xml release:prepare  -DpreparationGoals=clean -DskipTests=true
+          mvn -B -ntp clean
 
       - name: Checkout tag
         run: ./.github/scripts/release_checkout_tag.sh release.properties
@@ -209,7 +209,7 @@ jobs:
       - name: Deploy local staged artifacts
         working-directory: ./prepare-release-workspace/
         # If we don't want to close the repository we can add -DskipStagingRepositoryClose=true
-        run: mvn -B --file pom.xml org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/home/runner/local-staging
+        run: mvn -B -ntp --file pom.xml org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/home/runner/local-staging
 
       - name: Rollback release on failure
         working-directory: ./prepare-release-workspace/

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -66,7 +66,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get -y install autoconf automake libtool make tar rustc cargo git
 
     - name: Build project
-      run: ./mvnw clean package -DskipTests=true
+      run: ./mvnw -B -ntp clean package -DskipTests=true
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/docker/docker-compose.centos-6.yaml
+++ b/docker/docker-compose.centos-6.yaml
@@ -19,15 +19,15 @@ services:
 
   build-leak:
     <<: *common
-    command: /bin/bash -cl "mvn -Pleak clean test -Dio.netty.testsuite.badHost=netty.io"
+    command: /bin/bash -cl "./mvnw -B -ntp -Pleak clean test -Dio.netty.testsuite.badHost=netty.io"
 
   build: 
     <<: *common
-    command: /bin/bash -cl "mvn clean package -Dio.netty.testsuite.badHost=netty.io"
+    command: /bin/bash -cl "./mvnw -B -ntp clean package -Dio.netty.testsuite.badHost=netty.io"
 
   deploy:
     <<: *common
-    command: /bin/bash -cl "mvn clean deploy -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -B -ntp clean deploy -DskipTests=true"
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg
@@ -42,7 +42,7 @@ services:
       - ~/.m2:/root/.m2
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "mvn clean javadoc:jar package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -B -ntp clean javadoc:jar package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
 
   stage-release:
     <<: *common
@@ -55,7 +55,7 @@ services:
       - ~/.m2:/root/.m2
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && mvn -B clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"
+    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && ./mvnw -B -ntp clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"
 
 
   shell:

--- a/docker/docker-compose.centos-7.yaml
+++ b/docker/docker-compose.centos-7.yaml
@@ -22,7 +22,7 @@ services:
 
   cross-compile-aarch64-deploy:
     <<: *cross-compile-aarch64-common
-    command: /bin/bash -cl "mvn clean deploy -Plinux,linux-aarch64 -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -B -ntp clean deploy -Plinux,linux-aarch64 -DskipTests=true"
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg
@@ -38,7 +38,7 @@ services:
       - ~/.m2:/root/.m2
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "mvn -Plinux,linux-aarch64 clean javadoc:jar package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -B -ntp -Plinux,linux-aarch64 clean javadoc:jar package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
 
   cross-compile-aarch64-stage-release:
     <<: *cross-compile-aarch64-common
@@ -51,7 +51,7 @@ services:
       - ~/.m2:/root/.m2
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && mvn -B -Plinux,linux-aarch64 clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"
+    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && ./mvnw -B -ntp -Plinux,linux-aarch64 clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"
 
   cross-compile-aarch64-shell:
     <<: *cross-compile-aarch64-common
@@ -64,4 +64,4 @@ services:
 
   cross-compile-aarch64-build:
     <<: *cross-compile-aarch64-common
-    command: /bin/bash -cl "mvn clean package -Plinux,linux-aarch64 -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -B -ntp clean package -Plinux,linux-aarch64 -DskipTests=true"


### PR DESCRIPTION
Motivation:
When Maven does not run in batch mode, it will continuously print its progress as it downloads dependencies.
This can produce a very large amount of log output, that makes it harder to debug build failures.

Modification:
- Make all Maven builds run in batch mode by adding the -B command line flag.
- Some builds were already running batch mode but had the flag in a different location – these have had their -B flag moved so all builds are consistent.
- Add -ntp flag

Result:
Much less output in our build logs where Maven is just downloading stuff.