### PR TITLE
Ensure we include hs_err* files when build failed

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -68,4 +68,6 @@ jobs:
         if: ${{ failure() }}
         with:
           name: target
-          path: "**/target/"
+          path: |
+            **/target/surefire-reports/
+            **/hs_err*.log

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -90,7 +90,9 @@ jobs:
         if: ${{ failure() }}
         with:
           name: target
-          path: "**/target/"
+          path: |
+            **/target/surefire-reports/
+            **/hs_err*.log
 
   build-pr-qemu:
     runs-on: ubuntu-20.04
@@ -147,4 +149,6 @@ jobs:
         if: ${{ failure() }}
         with:
           name: build-target
-          path: "**/target/"
+          path: |
+            **/target/surefire-reports/
+            **/hs_err*.log


### PR DESCRIPTION
Motivation:

We the build failed we should ensure we also include hs_err* files as it may have failed due a native crash

Modifications:

Adjust path matching to include hs_err as well

Result:

Easier to debug native crashes