### PR TITLE
Fix netty test 4.1.68

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,8 +86,8 @@
 
     <checkstyle.version>8.38</checkstyle.version>
     <junit.version>4.13.1</junit.version>
-    <netty.version>4.1.65.Final</netty.version>
-    <netty-tcnative-boringssl-static.version>2.0.39.Final</netty-tcnative-boringssl-static.version>
+    <netty.version>4.1.68.Final</netty.version>
+    <netty-tcnative-boringssl-static.version>2.0.43.Final</netty-tcnative-boringssl-static.version>
 
     <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
     <maven-bundle-plugin.version>5.1.1</maven-bundle-plugin.version>

--- a/src/test/java/io/netty/incubator/channel/uring/IOUringDatagramUnicastTest.java
+++ b/src/test/java/io/netty/incubator/channel/uring/IOUringDatagramUnicastTest.java
@@ -28,6 +28,9 @@ import io.netty.channel.FixedRecvByteBufAllocator;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.channel.socket.InternetProtocolFamily;
+import io.netty.channel.unix.DomainDatagramChannel;
+import io.netty.channel.unix.DomainDatagramPacket;
+import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.channel.unix.Errors;
 import io.netty.channel.unix.SegmentedDatagramPacket;
 import io.netty.testsuite.transport.TestsuitePermutation;
@@ -36,8 +39,10 @@ import io.netty.util.ReferenceCountUtil;
 import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -45,6 +50,8 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class IOUringDatagramUnicastTest extends DatagramUnicastTest {
 
@@ -59,8 +66,13 @@ public class IOUringDatagramUnicastTest extends DatagramUnicastTest {
     }
 
     @Test(timeout = 8000)
-    public void testRecvMsgDontBlock() throws Throwable {
-        run();
+    public void testRecvMsgDontBlock(TestInfo testInfo) throws Throwable {
+        run(testInfo, new Runner<Bootstrap, Bootstrap>() {
+            @Override
+            public void run(Bootstrap bootstrap, Bootstrap bootstrap2) throws Throwable {
+                testRecvMsgDontBlock(bootstrap, bootstrap2);
+            }
+        });
     }
 
     public void testRecvMsgDontBlock(Bootstrap sb, Bootstrap cb) throws Throwable {
@@ -106,8 +118,13 @@ public class IOUringDatagramUnicastTest extends DatagramUnicastTest {
     }
 
     @Test
-    public void testSendSegmentedDatagramPacket() throws Throwable {
-        run();
+    public void testSendSegmentedDatagramPacket(TestInfo testInfo) throws Throwable {
+        run(testInfo, new Runner<Bootstrap, Bootstrap>() {
+            @Override
+            public void run(Bootstrap bootstrap, Bootstrap bootstrap2) throws Throwable {
+                testSendSegmentedDatagramPacket(bootstrap, bootstrap2);
+            }
+        });
     }
 
     public void testSendSegmentedDatagramPacket(Bootstrap sb, Bootstrap cb) throws Throwable {
@@ -185,6 +202,97 @@ public class IOUringDatagramUnicastTest extends DatagramUnicastTest {
             if (sc != null) {
                 sc.close().sync();
             }
+        }
+    }
+
+    @Override
+    protected boolean isConnected(Channel channel) {
+        return ((DomainDatagramChannel) channel).isConnected();
+    }
+
+    @Override
+    protected Channel setupClientChannel(Bootstrap bootstrap, byte[] bytes, CountDownLatch countDownLatch, AtomicReference<Throwable> errorRef) throws Throwable {
+        cb.handler(new SimpleChannelInboundHandler<DomainDatagramPacket>() {
+
+            @Override
+            public void channelRead0(ChannelHandlerContext ctx, DomainDatagramPacket msg) {
+                try {
+                    ByteBuf buf = msg.content();
+                    assertEquals(bytes.length, buf.readableBytes());
+                    for (int i = 0; i < bytes.length; i++) {
+                        assertEquals(bytes[i], buf.getByte(buf.readerIndex() + i));
+                    }
+
+                    assertEquals(ctx.channel().localAddress(), msg.recipient());
+                } finally {
+                    countDownLatch.countDown();
+                }
+            }
+
+            @Override
+            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                errorRef.compareAndSet(null, cause);
+            }
+        });
+        return cb.bind(newSocketAddress()).sync().channel();
+    }
+
+    @Override
+    protected Channel setupServerChannel(Bootstrap bootstrap, byte[] bytes, SocketAddress sender, CountDownLatch countDownLatch,
+                                         AtomicReference<Throwable> errorRef, boolean echo) throws Throwable {
+        sb.handler(new SimpleChannelInboundHandler<DomainDatagramPacket>() {
+
+            @Override
+            public void channelRead0(ChannelHandlerContext ctx, DomainDatagramPacket msg) {
+                try {
+                    if (sender == null) {
+                        assertNotNull(msg.sender());
+                    } else {
+                        assertEquals(sender, msg.sender());
+                    }
+
+                    ByteBuf buf = msg.content();
+                    assertEquals(bytes.length, buf.readableBytes());
+                    for (int i = 0; i < bytes.length; i++) {
+                        assertEquals(bytes[i], buf.getByte(buf.readerIndex() + i));
+                    }
+
+                    assertEquals(ctx.channel().localAddress(), msg.recipient());
+
+                    if (echo) {
+                        ctx.writeAndFlush(new DomainDatagramPacket(buf.retainedDuplicate(), msg.sender()));
+                    }
+                } finally {
+                    countDownLatch.countDown();
+                }
+            }
+
+            @Override
+            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                errorRef.compareAndSet(null, cause);
+            }
+        });
+        return sb.bind(newSocketAddress()).sync().channel();
+    }
+
+    @Override
+    protected boolean supportDisconnect() {
+        return false;
+    }
+
+    @Override
+    protected ChannelFuture write(Channel cc, ByteBuf buf, SocketAddress remote, WrapType wrapType) {
+        switch (wrapType) {
+            case DUP:
+                return cc.write(new DomainDatagramPacket(buf.retainedDuplicate(), (DomainSocketAddress) remote));
+            case SLICE:
+                return cc.write(new DomainDatagramPacket(buf.retainedSlice(), (DomainSocketAddress) remote));
+            case READ_ONLY:
+                return cc.write(new DomainDatagramPacket(buf.retain().asReadOnly(), (DomainSocketAddress) remote));
+            case NONE:
+                return cc.write(new DomainDatagramPacket(buf.retain(), (DomainSocketAddress) remote));
+            default:
+                throw new Error("unknown wrap type: " + wrapType);
         }
     }
 }

--- a/src/test/java/io/netty/incubator/channel/uring/IOUringSocketConditionalWritabilityTest.java
+++ b/src/test/java/io/netty/incubator/channel/uring/IOUringSocketConditionalWritabilityTest.java
@@ -21,6 +21,7 @@ import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketConditionalWritabilityTest;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import java.util.List;
 
@@ -40,7 +41,7 @@ public class IOUringSocketConditionalWritabilityTest extends SocketConditionalWr
 
     @Test
     @Override
-    public void testConditionalWritability() throws Throwable {
+    public void testConditionalWritability(TestInfo testInfo) throws Throwable {
         // Ignore as it does not pass on QEMU atm
         // super.testConditionalWritability();
     }

--- a/src/test/java/io/netty/incubator/channel/uring/IOUringSocketHalfClosedTest.java
+++ b/src/test/java/io/netty/incubator/channel/uring/IOUringSocketHalfClosedTest.java
@@ -24,6 +24,7 @@ import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import java.util.List;
 
@@ -43,9 +44,13 @@ public class IOUringSocketHalfClosedTest extends SocketHalfClosedTest {
 
     @Ignore
     @Test
-    public void testAutoCloseFalseDoesShutdownOutput() throws Throwable {
+    public void testAutoCloseFalseDoesShutdownOutput(TestInfo testInfo) throws Throwable {
         // This test only works on Linux / BSD / MacOS as we assume some semantics that are not true for Windows.
         Assume.assumeFalse(PlatformDependent.isWindows());
-        run();
+        this.run(testInfo, new Runner<ServerBootstrap, Bootstrap>() {
+            public void run(ServerBootstrap serverBootstrap, Bootstrap bootstrap) throws Throwable {
+                testHalfClosureOnlyOneEventWhenAutoRead(serverBootstrap, bootstrap);
+            }
+        });
     }
 }

--- a/src/test/java/io/netty/incubator/channel/uring/IOUringSocketHalfClosedTest.java
+++ b/src/test/java/io/netty/incubator/channel/uring/IOUringSocketHalfClosedTest.java
@@ -49,7 +49,7 @@ public class IOUringSocketHalfClosedTest extends SocketHalfClosedTest {
         Assume.assumeFalse(PlatformDependent.isWindows());
         this.run(testInfo, new Runner<ServerBootstrap, Bootstrap>() {
             public void run(ServerBootstrap serverBootstrap, Bootstrap bootstrap) throws Throwable {
-                testHalfClosureOnlyOneEventWhenAutoRead(serverBootstrap, bootstrap);
+                testAutoCloseFalseDoesShutdownOutput(serverBootstrap, bootstrap);
             }
         });
     }

--- a/src/test/java/io/netty/incubator/channel/uring/IOUringSocketShutdownOutputBySelfTest.java
+++ b/src/test/java/io/netty/incubator/channel/uring/IOUringSocketShutdownOutputBySelfTest.java
@@ -20,6 +20,7 @@ import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketShutdownOutputBySelfTest;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import java.util.List;
 
@@ -39,7 +40,7 @@ public class IOUringSocketShutdownOutputBySelfTest extends SocketShutdownOutputB
 
     @Test
     @Override
-    public void testWriteAfterShutdownOutputNoWritabilityChange() throws Throwable {
+    public void testWriteAfterShutdownOutputNoWritabilityChange(TestInfo testInfo) throws Throwable {
         // Ignore as it does not pass on QEMU atm
         // super.testWriteAfterShutdownOutputNoWritabilityChange();
     }

--- a/src/test/java/io/netty/incubator/channel/uring/IOUringSocketSslClientRenegotiateTest.java
+++ b/src/test/java/io/netty/incubator/channel/uring/IOUringSocketSslClientRenegotiateTest.java
@@ -28,9 +28,6 @@ import static org.junit.Assume.assumeTrue;
 
 public class IOUringSocketSslClientRenegotiateTest extends SocketSslClientRenegotiateTest {
 
-    public IOUringSocketSslClientRenegotiateTest(SslContext serverCtx, SslContext clientCtx, boolean delegate) {
-        super(serverCtx, clientCtx, delegate);
-    }
 
     @BeforeClass
     public static void loadJNI() {

--- a/src/test/java/io/netty/incubator/channel/uring/IOUringSocketSslEchoTest.java
+++ b/src/test/java/io/netty/incubator/channel/uring/IOUringSocketSslEchoTest.java
@@ -27,15 +27,6 @@ import java.util.List;
 import static org.junit.Assume.assumeTrue;
 
 public class IOUringSocketSslEchoTest extends SocketSslEchoTest {
-    public IOUringSocketSslEchoTest(
-            SslContext serverCtx, SslContext clientCtx, Renegotiation renegotiation,
-            boolean serverUsesDelegatedTaskExecutor, boolean clientUsesDelegatedTaskExecutor,
-            boolean autoRead, boolean useChunkedWriteHandler, boolean useCompositeByteBuf) {
-
-        super(serverCtx, clientCtx, renegotiation,
-                serverUsesDelegatedTaskExecutor, clientUsesDelegatedTaskExecutor,
-                autoRead, useChunkedWriteHandler, useCompositeByteBuf);
-    }
 
     @BeforeClass
     public static void loadJNI() {

--- a/src/test/java/io/netty/incubator/channel/uring/IOUringSocketSslGreetingTest.java
+++ b/src/test/java/io/netty/incubator/channel/uring/IOUringSocketSslGreetingTest.java
@@ -28,9 +28,6 @@ import static org.junit.Assume.assumeTrue;
 
 public class IOUringSocketSslGreetingTest  extends SocketSslGreetingTest {
 
-    public IOUringSocketSslGreetingTest(SslContext serverCtx, SslContext clientCtx, boolean delegate) {
-        super(serverCtx, clientCtx, delegate);
-    }
 
     @BeforeClass
     public static void loadJNI() {

--- a/src/test/java/io/netty/incubator/channel/uring/IOUringSocketSslSessionReuseTest.java
+++ b/src/test/java/io/netty/incubator/channel/uring/IOUringSocketSslSessionReuseTest.java
@@ -28,10 +28,6 @@ import static org.junit.Assume.assumeTrue;
 
 public class IOUringSocketSslSessionReuseTest extends SocketSslSessionReuseTest {
 
-    public IOUringSocketSslSessionReuseTest(SslContext serverCtx, SslContext clientCtx) {
-        super(serverCtx, clientCtx);
-    }
-
     @BeforeClass
     public static void loadJNI() {
         assumeTrue(IOUring.isAvailable());

--- a/src/test/java/io/netty/incubator/channel/uring/IOUringSocketStartTlsTest.java
+++ b/src/test/java/io/netty/incubator/channel/uring/IOUringSocketStartTlsTest.java
@@ -28,10 +28,6 @@ import static org.junit.Assume.assumeTrue;
 
 public class IOUringSocketStartTlsTest extends SocketStartTlsTest {
 
-    public IOUringSocketStartTlsTest(SslContext serverCtx, SslContext clientCtx) {
-        super(serverCtx, clientCtx);
-    }
-
     @BeforeClass
     public static void loadJNI() {
         assumeTrue(IOUring.isAvailable());


### PR DESCRIPTION
Hello, I just saw this morning this [(Pull Request)](https://github.com/netty/netty-incubator-transport-io_uring/pull/110)
I made this PR to try to fix the test since netty has changed JUnit version that add TestInfo and other change.
Based on Epoll test for the setupClientChannel part

Hope it will help.