### PR TITLE
Ensure we generate a correct OSGI compatible manifest for all our jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -392,6 +392,7 @@
             <configuration>
               <target>
                 <copy file="${project.build.outputDirectory}/META-INF/MANIFEST.MF" tofile="${project.build.directory}/manifests/MANIFEST.MF" />
+                <copy file="${project.build.outputDirectory}/META-INF/MANIFEST.MF" tofile="${project.build.directory}/manifests/MANIFEST-native.MF" />
               </target>
             </configuration>
           </execution>


### PR DESCRIPTION
Motivation:

As we generate two jars (one with native lib included and one without) we need to ensure both contain the correct entries to be able to use these with OSGI

Modifications:

Adjust build configuration to generate the correct manifests

Result:

Correct manifest file for our jars