### PR TITLE
Fix dependencies so junit5 tests are run

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,13 +168,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${maven-surefire-plugin.version}</version>
-          <dependencies>
-            <dependency>
-              <groupId>org.apache.maven.surefire</groupId>
-              <artifactId>surefire-junit4</artifactId>
-              <version>${maven-surefire-plugin.version}</version>
-            </dependency>
-          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.fusesource.hawtjni</groupId>
@@ -435,12 +428,6 @@
         <groupId>io.netty</groupId>
         <artifactId>netty-build-common</artifactId>
         <version>${netty.build.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven.surefire</groupId>
-        <artifactId>surefire-junit4</artifactId>
-        <version>${maven-surefire-plugin.version}</version>
         <scope>test</scope>
       </dependency>
     </dependencies>

--- a/transport-native-io_uring/pom.xml
+++ b/transport-native-io_uring/pom.xml
@@ -305,10 +305,5 @@
       <artifactId>netty-build-common</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.maven.surefire</groupId>
-      <artifactId>surefire-junit4</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Motivation:

We did miss to update the dependencies when upgrading to junit 5 so the tests did not run anymore

Modifications:

Remove junit4 dependencies

Result:

junit tests run again