### PR TITLE
Use correct junit5 annotation to execute before method

### DIFF
--- a/transport-native-io_uring/src/test/java/io/netty/incubator/channel/uring/IOUringSocketSslGreetingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/incubator/channel/uring/IOUringSocketSslGreetingTest.java
@@ -17,10 +17,9 @@ package io.netty.incubator.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.handler.ssl.SslContext;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketSslGreetingTest;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 import java.util.List;
 
@@ -28,7 +27,7 @@ import static org.junit.Assume.assumeTrue;
 
 public class IOUringSocketSslGreetingTest extends SocketSslGreetingTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void loadJNI() {
         assumeTrue(IOUring.isAvailable());
     }


### PR DESCRIPTION
Motivation:

In one class we still used @BeforeClass while we should have used @BeforeAll. This caused the method to never been executed and so could lead to failures.

Modifications:

Replace @BeforeClass with @BeforeAll

Result:

Build fails no-more