### PR TITLE
Add test that native io_uring and native epoll transport can co-exist

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -420,6 +420,12 @@
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
+        <artifactId>netty-transport-classes-epoll</artifactId>
+        <version>${netty.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
         <artifactId>netty-tcnative-boringssl-static</artifactId>
         <version>${netty-tcnative-boringssl-static.version}</version>
         <scope>test</scope>

--- a/transport-native-io_uring/pom.xml
+++ b/transport-native-io_uring/pom.xml
@@ -243,6 +243,14 @@
           -->
           <optional>true</optional>
         </dependency>
+
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+          <version>${netty.version}</version>
+          <scope>test</scope>
+          <classifier>${jni.classifier}</classifier>
+        </dependency>
       </dependencies>
     </profile>
     <profile>
@@ -293,6 +301,11 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-unix-common-tests</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-classes-epoll</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/transport-native-io_uring/src/test/java/io/netty/incubator/channel/uring/IOUringAndEpollTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/incubator/channel/uring/IOUringAndEpollTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.incubator.channel.uring;
+
+import io.netty.channel.epoll.Epoll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IOUringAndEpollTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
+    @Test
+    public void testIOUringAndEpollCanBothBeLoaded() {
+        IOUring.ensureAvailability();
+        Epoll.ensureAvailability();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty/incubator/channel/uring/IOUringAndEpollTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/incubator/channel/uring/IOUringAndEpollTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Netty Project
+ * Copyright 2021 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance


### PR DESCRIPTION
Motivation:

We should add a test to ensure that its possible to have the native io_uring transport and the native epoll transport on the same classpath and load them.

Modifications:

- Add test dependency on native epoll transport
- Add test case

Result:

Ensure both transports can exist on the classpath without problems