### PR TITLE
Add Fragment-Host declaration to bundles shipping native libs

### DIFF
--- a/transport-native-io_uring/pom.xml
+++ b/transport-native-io_uring/pom.xml
@@ -30,6 +30,7 @@
 
   <properties>
     <javaModuleName>io.netty.incubator.transport.io_uring</javaModuleName>
+    <fragmentHost>io.netty.incubator.netty-incubator-transport-classes-io_uring</fragmentHost>
     <unix.common.lib.name>netty-unix-common</unix.common.lib.name>
     <unix.common.lib.dir>${project.build.directory}/unix-common-lib</unix.common.lib.dir>
     <unix.common.lib.unpacked.dir>${unix.common.lib.dir}/META-INF/native/lib</unix.common.lib.unpacked.dir>
@@ -219,6 +220,7 @@
                     <manifestEntries>
                       <Bundle-NativeCode>META-INF/native/libnetty_transport_native_io_uring_${jniArch}.so; osname=Linux; processor=${jniArch},*</Bundle-NativeCode>
                       <Automatic-Module-Name>${javaModuleName}</Automatic-Module-Name>
+                      <Fragment-Host>${fragmentHost}</Fragment-Host>
                     </manifestEntries>
                     <index>true</index>
                     <manifestFile>${project.build.directory}/manifests/MANIFEST-native.MF</manifestFile>
@@ -240,7 +242,7 @@
                 </goals>
                 <configuration>
                   <includes>
-	   	    <include>**/CombinationOfIOUringAndEpollTest.java</include>
+                    <include>**/CombinationOfIOUringAndEpollTest.java</include>
                   </includes>
                   <reuseForks>false</reuseForks>
                 </configuration>
@@ -253,7 +255,7 @@
                 </goals>
                 <configuration>
                   <includes>
-		    <include>**/CombinationOfEpollAndIOUringTest.java</include>
+                    <include>**/CombinationOfEpollAndIOUringTest.java</include>
                   </includes>
                   <runOrder>random</runOrder>
                   <systemPropertyVariables>


### PR DESCRIPTION
Motivation:

We need to add a Fragment-Host entry to the manifest for the jars that contain the native libs so its possible to use these in OSGI.

Modifications:

Add Fragment-Host entry to manifest.

Result:

Be able to use via OSGI