### PR TITLE
Allow to enforce io_uring usage

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUring.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUring.java
@@ -25,15 +25,12 @@ public final class IOUring {
     static {
         Throwable cause = null;
         try {
-            String kernelVersion = Native.kernelVersion();
-
             if (SystemPropertyUtil.getBoolean("io.netty.transport.noNative", false)) {
                 cause = new UnsupportedOperationException(
                         "Native transport was explicit disabled with -Dio.netty.transport.noNative=true");
-            } else if (!Native.checkKernelVersion(kernelVersion)) {
-                cause = new UnsupportedOperationException(
-                        "you need at least kernel version 5.9, current kernel version: " + kernelVersion);
             } else {
+                String kernelVersion = Native.kernelVersion();
+                Native.checkKernelVersion(kernelVersion);
                 Throwable unsafeCause = PlatformDependent.getUnsafeUnavailabilityCause();
                 if (unsafeCause == null) {
                     RingBuffer ringBuffer = null;

--- a/transport-native-io_uring/src/test/java/io/netty/incubator/channel/uring/NativeTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/incubator/channel/uring/NativeTest.java
@@ -28,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -307,13 +308,15 @@ public class NativeTest {
 
     @Test
     public void parsingKernelVersionTest() {
-        assertTrue(Native.checkKernelVersion("10.11.123"));
-        assertFalse(Native.checkKernelVersion("5.8.1-23"));
-        assertTrue(Native.checkKernelVersion("5.100.1-1"));
-        assertTrue(Native.checkKernelVersion("5.9.1-1"));
-        assertTrue(Native.checkKernelVersion("5.9.100-1"));
-        assertFalse(Native.checkKernelVersion("5.5.67"));
-        assertFalse(Native.checkKernelVersion("5.5.32"));
-        assertFalse(Native.checkKernelVersion("4.16.20"));
+        Native.checkKernelVersion("10.11.123");
+        assertThrows(UnsupportedOperationException.class, () -> Native.checkKernelVersion("5.8.1-23"));
+
+        Native.checkKernelVersion("5.100.1-1");
+        Native.checkKernelVersion("5.9.1-1");
+        Native.checkKernelVersion("5.9.100-1");
+
+        assertThrows(UnsupportedOperationException.class, () -> Native.checkKernelVersion("5.5.67"));
+        assertThrows(UnsupportedOperationException.class, () -> Native.checkKernelVersion("5.5.32"));
+        assertThrows(UnsupportedOperationException.class, () -> Native.checkKernelVersion("4.16.20"));
     }
 }


### PR DESCRIPTION
Motivation:

By default we not try to use io_uring when the kernel is < 5.9. While this is a good default there might be sitations when the user still wants to try using it, for example if another kernel is used but io_uring was backported

Modifications:

Add io.netty.transport.uring.enforceKernelVersion property which can be used to control enforcement of kernel version (default is true).

Result:

Allow to use io_uring even if the kernel not matches requirements