### PR TITLE
Fix typos in system properties

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/Native.java
@@ -33,9 +33,9 @@ import java.util.Locale;
 
 final class Native {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(Native.class);
-    static final int DEFAULT_RING_SIZE = Math.max(64, SystemPropertyUtil.getInt("io.netty.uring.ringSize", 4096));
+    static final int DEFAULT_RING_SIZE = Math.max(64, SystemPropertyUtil.getInt("io.netty.iouring.ringSize", 4096));
     static final int DEFAULT_IOSEQ_ASYNC_THRESHOLD =
-            Math.max(0, SystemPropertyUtil.getInt("io.netty.uring.iosqeAsyncThreshold", 25));
+            Math.max(0, SystemPropertyUtil.getInt("io.netty.iouring.iosqeAsyncThreshold", 25));
 
     static {
         Selector selector = null;


### PR DESCRIPTION
Motivation:

We used .uring. in the system properties but it should be .iouring. to be consistent

Modifications:

Fix property names

Result:

Correct naming