### PR TITLE
Don't leak temporary file during test and inital loading of lib.

### DIFF
--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -296,8 +296,12 @@ static jobjectArray netty_io_uring_setup(JNIEnv *env, jclass clazz, jint entries
     return array;
 }
 
-static jint netty_create_file(JNIEnv *env, jclass class) {
-    return open("io-uring-test.txt", O_RDWR | O_TRUNC | O_CREAT, 0644);
+static jint netty_create_file(JNIEnv *env, jclass class, jstring filename) {
+    const char *file = env->GetStringUTFChars(filename, 0);
+
+    int fd =  open(file, O_RDWR | O_TRUNC | O_CREAT, 0644);
+    env->ReleaseStringUTFChars(filename, file);
+    return fd;
 }
 
 
@@ -592,7 +596,7 @@ static const JNINativeMethod method_table[] = {
     {"ioUringSetup", "(I)[[J", (void *) netty_io_uring_setup},
     {"ioUringProbe", "(I[I)Z", (void *) netty_io_uring_probe},
     {"ioUringExit", "(JIJIJII)V", (void *) netty_io_uring_ring_buffer_exit},
-    {"createFile", "()I", (void *) netty_create_file},
+    {"createFile", "(Ljava/lang/String;)I", (void *) netty_create_file},
     {"ioUringEnter", "(IIII)I", (void *) netty_io_uring_enter},
     {"blockingEventFd", "()I", (void *) netty_epoll_native_blocking_event_fd},
     {"eventFdWrite", "(IJ)V", (void *) netty_io_uring_eventFdWrite },

--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -297,10 +297,10 @@ static jobjectArray netty_io_uring_setup(JNIEnv *env, jclass clazz, jint entries
 }
 
 static jint netty_create_file(JNIEnv *env, jclass class, jstring filename) {
-    const char *file = env->GetStringUTFChars(filename, 0);
+    const char *file = (*env)->GetStringUTFChars(env, filename, 0);
 
     int fd =  open(file, O_RDWR | O_TRUNC | O_CREAT, 0644);
-    env->ReleaseStringUTFChars(filename, file);
+    (*env)->ReleaseStringUTFChars(env, filename, file);
     return fd;
 }
 

--- a/transport-native-io_uring/src/test/java/io/netty/incubator/channel/uring/NativeTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/incubator/channel/uring/NativeTest.java
@@ -48,9 +48,6 @@ public class NativeTest {
         assumeTrue(IOUring.isAvailable());
     }
 
-
-
-
     @Test
     public void canWriteFile(@TempDir Path tmpDir) throws Exception {
         ByteBufAllocator allocator = new UnpooledByteBufAllocator(true);

--- a/transport-native-io_uring/src/test/java/io/netty/incubator/channel/uring/NativeTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/incubator/channel/uring/NativeTest.java
@@ -17,7 +17,9 @@ package io.netty.incubator.channel.uring;
 
 import io.netty.channel.unix.FileDescriptor;
 
+import java.io.File;
 import java.nio.charset.Charset;
+import java.nio.file.Path;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -37,6 +39,7 @@ import io.netty.buffer.ByteBuf;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
 
 public class NativeTest {
 
@@ -45,14 +48,18 @@ public class NativeTest {
         assumeTrue(IOUring.isAvailable());
     }
 
+
+
+
     @Test
-    public void canWriteFile() throws Exception {
+    public void canWriteFile(@TempDir Path tmpDir) throws Exception {
         ByteBufAllocator allocator = new UnpooledByteBufAllocator(true);
         final ByteBuf writeEventByteBuf = allocator.directBuffer(100);
         final String inputString = "Hello World!";
         writeEventByteBuf.writeCharSequence(inputString, Charset.forName("UTF-8"));
 
-        int fd = Native.createFile();
+        Path file = tmpDir.resolve("io_uring.tmp");
+        int fd = Native.createFile(file.toString());
 
         RingBuffer ringBuffer = Native.createRingBuffer(32);
         IOUringSubmissionQueue submissionQueue = ringBuffer.ioUringSubmissionQueue();


### PR DESCRIPTION
Motivation:

We did leak a file during our tests and also during the initial loading of the native lib

Modifications:

Use a tempory file / directory and so ensure the file is deleted

Result:

No leaked file