### PR TITLE
Update netty-tcnative-boringssl-static to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <checkstyle.version>8.38</checkstyle.version>
     <junit.version>5.7.0</junit.version>
     <netty.version>4.1.74.Final</netty.version>
-    <netty-tcnative-boringssl-static.version>2.0.48.Final</netty-tcnative-boringssl-static.version>
+    <netty-tcnative-boringssl-static.version>2.0.50.Final</netty-tcnative-boringssl-static.version>
     <bouncycastle.version>1.68</bouncycastle.version>
     <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
     <maven-bundle-plugin.version>5.1.1</maven-bundle-plugin.version>


### PR DESCRIPTION
Motivation:

We should use the latest netty-tcnative release in tests

Modifications:

Upgrade version

Result:

Use latest release