### PR TITLE
nextWakupNanos lazySet.

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUringEventLoop.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUringEventLoop.java
@@ -166,7 +166,10 @@ public final class IOUringEventLoop extends SingleThreadEventLoop {
                 if (curDeadlineNanos == -1L) {
                     curDeadlineNanos = NONE; // nothing on the calendar
                 }
-                nextWakeupNanos.set(curDeadlineNanos);
+
+                // The memory ordering effects of the nextWakeupNanos are irrelevant. A setOpaque should be sufficient,
+                // but on Java 8 the lazySet is the cheapest alternative. It is free on X86 since every store is a release store.
+                nextWakeupNanos.lazySet(curDeadlineNanos);
 
                 // Only submit a timeout if there are no tasks to process and do a blocking operation
                 // on the completionQueue.


### PR DESCRIPTION
The memory ordering effects of the nextWakupNanos are irrelevant. We
just need to make sure that the compiler doesn't optimize out the load
or the store. A setOpaque should be sufficient. But since the code needs
to be Java 8 compatible, setRelease is the cheapest alternative.

This will restrict compiler optimizations but doesn't lead to a memory
fence on the X86 since every store is a release store (the semantics
provided by a setLazy).

In a subsequent PR I'll deal with the getAndSet in the finally clause.