### PR TITLE
Upgrade to Maven 3.8.6

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/apache-maven/3.8.5/apache-maven-3.8.5-bin.zip
+distributionUrl=https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip


### PR DESCRIPTION
Motivation:
Maven 3.8.6 is available with various changes.

See: https://lists.apache.org/thread/44817jckpzy7gtrkds9xfrgybmrrbm1z

Modification:
Upgraded to Maven 3.8.6

Result:
The latest version of Maven