### PR TITLE
Add build files for MacOS/M1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+.PHONY: set-arch build run-build shell
+.DEFAULT_GOAL := run-build
+
+arch=$(shell uname -m)
+set-arch:
+ifeq ($(arch),aarch64)
+	arch=arm64
+endif
+
+build: set-arch
+ifeq ($(arch),arm64)
+	docker-compose -f docker/docker-compose.centos-7arm.yaml build
+else
+	docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml build
+endif
+
+run-build: build
+ifeq ($(arch),arm64)
+	docker-compose -f docker/docker-compose.centos-7arm.yaml run compile-aarch64-build
+else
+	docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml run build-leak
+endif
+
+shell: build
+ifeq ($(arch),arm64)
+	docker-compose -f docker/docker-compose.centos-7arm.yaml run compile-aarch64-shell
+else
+	docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml run shell
+endif

--- a/docker/Dockerfile.centos7arm64v8
+++ b/docker/Dockerfile.centos7arm64v8
@@ -1,0 +1,44 @@
+FROM arm64v8/centos:7.9.2009
+
+# Install requirements
+RUN yum install -y \
+	apr-devel \
+	autoconf \
+	automake \
+	git \
+	glibc-devel \
+	libaio-devel \
+	libtool \
+	lksctp-tools \
+	make \
+	openssl-devel \
+	redhat-lsb-core \
+	tar \
+	unzip \
+	wget \
+	zip
+
+# Downloading and installing SDKMAN!
+RUN curl -s "https://get.sdkman.io" | bash
+
+ARG java_version="8.0.322-zulu"
+ENV JAVA_VERSION $java_version
+
+# Installing Java removing some unnecessary SDKMAN files
+RUN bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && \
+    yes | sdk install java $JAVA_VERSION && \
+    rm -rf $HOME/.sdkman/archives/* && \
+    rm -rf $HOME/.sdkman/tmp/*"
+
+RUN echo 'export JAVA_HOME="/root/.sdkman/candidates/java/current"' >> ~/.bashrc
+RUN echo 'PATH=/root/.sdkman/candidates/java/current/bin:$PATH' >> ~/.bashrc
+
+WORKDIR /opt
+
+# Install maven
+RUN curl https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | tar -xz
+RUN echo 'PATH=/opt/apache-maven-3.6.3/bin/:$PATH' >> ~/.bashrc
+
+# Prepare our own build
+ENV PATH /opt/apache-maven-3.6.3/bin/:$PATH
+ENV JAVA_HOME /root/.sdkman/candidates/java/current/

--- a/docker/docker-compose.centos-7arm.yaml
+++ b/docker/docker-compose.centos-7arm.yaml
@@ -1,0 +1,33 @@
+version: "3"
+
+services:
+
+  compile-aarch64-runtime-setup:
+    image: netty-io_uring:compile_aarch64
+    build:
+      context: ../
+      dockerfile: docker/Dockerfile.centos7arm64v8
+      args:
+        java_version: "8.0.322-zulu"
+
+  compile-aarch64-common: &compile-aarch64-common
+    depends_on: [ compile-aarch64-runtime-setup ]
+    image: netty-io_uring:compile_aarch64
+    volumes:
+      - ~/.ssh:/root/.ssh:delegated
+      - ~/.m2/repository:/root/.m2/repository
+      - ..:/code:delegated
+    working_dir: /code
+
+  compile-aarch64-shell:
+    <<: *compile-aarch64-common
+    volumes:
+      - ~/.ssh:/root/.ssh:delegated
+      - ~/.gnupg:/root/.gnupg:delegated
+      - ..:/code:delegated
+      - ~/.m2:/root/.m2:delegated
+    entrypoint: /bin/bash
+
+  compile-aarch64-build:
+    <<: *compile-aarch64-common
+    command: /bin/bash -cl "mkdir -p transport-native-io_uring/target/generated-sources/hawtjni/native-package && touch transport-native-io_uring/target/generated-sources/hawtjni/native-package/autogen.sh && chmod a+x transport-native-io_uring/target/generated-sources/hawtjni/native-package/autogen.sh && ./mvnw -B -ntp package -Plinux,linux-aarch64-native -DskipTests=true"

--- a/transport-native-io_uring/pom.xml
+++ b/transport-native-io_uring/pom.xml
@@ -345,6 +345,16 @@
       </properties>
     </profile>
     <profile>
+      <id>linux-aarch64-native</id>
+      <properties>
+        <!-- use aarch_64 as this is also what os.detected.arch will use on an aarch64 system -->
+        <jniArch>aarch_64</jniArch>
+        <!-- As we cross-compile just skip the tests because we could not load this lib on the system anyway -->
+        <skipTests>true</skipTests>
+        <extraConfigureArg>--host=aarch64-linux-gnu</extraConfigureArg>
+      </properties>
+    </profile>
+    <profile>
       <id>leak</id>
       <properties>
         <test.argLine>-Dio.netty.leakDetectionLevel=paranoid -Dio.netty.leakDetection.targetRecords=32</test.argLine>


### PR DESCRIPTION
Motivation:
We're increasingly developing on MacOS/M1 machines, so it's useful to have a standard set-up for building and testing locally.

Modification:
Add another set of docker files for building native ARM (not cross-compiling) binaries. Add a Makefile to make it easy to start these builds or drop into the docker guest shell.

Result:
Easier development flow when working on a MacOS/M1 machine.