### PR TITLE
Enable workflows on the netty5 branch

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -17,7 +17,7 @@ name: Build project
 
 on:
   push:
-    branches: [ main ]
+    branches: [ netty5 ]
 
   schedule:
     - cron: '30 5 * * 1'  # At 05:30 on Monday, every Monday.

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -17,7 +17,7 @@ name: Deploy snapshots
 
 on:
   push:
-    branches: [ main ]
+    branches: [ netty5 ]
 
   schedule:
     - cron: '30 5 * * 1'  # At 05:30 on Monday, every Monday.

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -17,7 +17,7 @@ name: Build PR
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ netty5 ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: main
+          ref: netty5
 
       - name: Set up JDK 8
         uses: actions/setup-java@v1
@@ -154,7 +154,7 @@ jobs:
         working-directory: ./prepare-release-workspace/
         if: ${{ failure() }}
         # Rollback the release in case of an failure
-        run: bash ./.github/scripts/release_rollback.sh release.properties netty/netty-incubator-transport-io_uring main
+        run: bash ./.github/scripts/release_rollback.sh release.properties netty/netty-incubator-transport-io_uring nett5
 
   deploy-staged-release:
     runs-on: ubuntu-latest
@@ -224,4 +224,4 @@ jobs:
         working-directory: ./prepare-release-workspace/
         if: ${{ failure() }}
         # Rollback the release in case of an failure
-        run: bash ./.github/scripts/release_rollback.sh release.properties netty/netty-incubator-transport-io_uring main
+        run: bash ./.github/scripts/release_rollback.sh release.properties netty/netty-incubator-transport-io_uring netty5

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,10 +17,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main ]
+    branches: [ netty5 ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main ]
+    branches: [ netty5 ]
   schedule:
     - cron: '40 9 * * 1'
 


### PR DESCRIPTION
Motivation:
The workflow files need to know to build the netty5 branch as one of the mainline branches

Modification:
Change `main` for `netty5` in the workflow files.

Result:
Hopefully the builds are picked up now.