### PR TITLE
Upgrade BouncyCastle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <junit.version>5.9.0</junit.version>
     <netty.version>4.1.82.Final</netty.version>
     <netty-tcnative-boringssl-static.version>2.0.54.Final</netty-tcnative-boringssl-static.version>
-    <bouncycastle.version>1.68</bouncycastle.version>
+    <bouncycastle.version>1.71.1</bouncycastle.version>
     <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
     <maven-bundle-plugin.version>5.1.1</maven-bundle-plugin.version>
     <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
@@ -407,7 +407,7 @@
       <!-- Also include bouncycastle so we can use SelfSignedCertificate even on more recent JDKs during testing -->
       <dependency>
         <groupId>org.bouncycastle</groupId>
-        <artifactId>bcpkix-jdk15on</artifactId>
+        <artifactId>bcpkix-jdk18on</artifactId>
         <version>${bouncycastle.version}</version>
         <scope>test</scope>
       </dependency>

--- a/transport-native-io_uring/pom.xml
+++ b/transport-native-io_uring/pom.xml
@@ -405,7 +405,7 @@
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <artifactId>bcpkix-jdk18on</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Motivation:
We can use the Java 8 version of BouncyCastle now.

Modification:
Upgrade BouncyCastle to version 1.71.1 and switch to the Java 8 supporting variants.

Result:
Newer BouncyCastle.