### PR TITLE
Change maven module and artifact names

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,9 +23,9 @@
   </parent>
 
   <groupId>io.netty.incubator</groupId>
-  <artifactId>netty-incubator-transport-parent-io_uring</artifactId>
+  <artifactId>netty5-incubator-transport-parent-io_uring</artifactId>
   <version>0.0.16.Final-SNAPSHOT</version>
-  <name>Netty/Incubator/Transport/Parent/io_uring</name>
+  <name>Netty5/Incubator/Transport/Parent/io_uring</name>
   <packaging>pom</packaging>
   <url>https://netty.io/</url>
   <description>

--- a/transport-classes-io_uring/pom.xml
+++ b/transport-classes-io_uring/pom.xml
@@ -18,17 +18,17 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.netty.incubator</groupId>
-    <artifactId>netty-incubator-transport-parent-io_uring</artifactId>
+    <artifactId>netty5-incubator-transport-parent-io_uring</artifactId>
     <version>0.0.16.Final-SNAPSHOT</version>
   </parent>
 
-  <artifactId>netty-incubator-transport-classes-io_uring</artifactId>
+  <artifactId>netty5-incubator-transport-classes-io_uring</artifactId>
   <version>0.0.16.Final-SNAPSHOT</version>
-  <name>Netty/Incubator/Transport/Classes/io_uring</name>
+  <name>Netty5/Incubator/Transport/Classes/io_uring</name>
   <packaging>jar</packaging>
 
   <properties>
-    <javaModuleName>io.netty.incubator.transport.classes.io_uring</javaModuleName>
+    <javaModuleName>io.netty5.incubator.transport.classes.io_uring</javaModuleName>
   </properties>
 
   <build>

--- a/transport-native-io_uring/pom.xml
+++ b/transport-native-io_uring/pom.xml
@@ -18,19 +18,19 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.netty.incubator</groupId>
-    <artifactId>netty-incubator-transport-parent-io_uring</artifactId>
+    <artifactId>netty5-incubator-transport-parent-io_uring</artifactId>
     <version>0.0.16.Final-SNAPSHOT</version>
   </parent>
 
-  <artifactId>netty-incubator-transport-native-io_uring</artifactId>
+  <artifactId>netty5-incubator-transport-native-io_uring</artifactId>
   <version>0.0.16.Final-SNAPSHOT</version>
-  <name>Netty/Incubator/Transport/Native/io_uring</name>
+  <name>Netty5/Incubator/Transport/Native/io_uring</name>
   <packaging>jar</packaging>
 
 
   <properties>
-    <javaModuleName>io.netty.incubator.transport.io_uring</javaModuleName>
-    <fragmentHost>io.netty.incubator.netty-incubator-transport-classes-io_uring</fragmentHost>
+    <javaModuleName>io.netty5.incubator.transport.io_uring</javaModuleName>
+    <fragmentHost>io.netty.incubator.netty5-incubator-transport-classes-io_uring</fragmentHost>
     <unix.common.lib.name>netty-unix-common</unix.common.lib.name>
     <unix.common.lib.dir>${project.build.directory}/unix-common-lib</unix.common.lib.dir>
     <unix.common.lib.unpacked.dir>${unix.common.lib.dir}/META-INF/native/lib</unix.common.lib.unpacked.dir>


### PR DESCRIPTION
Motivation:
The modules and deliverables produces by the Netty 5 port needs to have separate maven coordinates from the Netty 4.1 version.

Modification:
Change maven artifact names to reflect that they're intended for Netty 5 integration.

Result:
Netty 5 and 4.1 versions can coexist in Maven (but currently still clash in their native library names)