### PR TITLE
Define MSG_FASTOPEN for older kernels

### DIFF
--- a/transport-native-io_uring/src/main/c/netty5_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty5_io_uring_native.c
@@ -57,6 +57,11 @@
 #define NETTY5_JNI_UTIL_BUILD_STATIC
 #endif
 
+// Allow to compile on systems with older kernels
+#ifndef MSG_FASTOPEN
+#define MSG_FASTOPEN 0x20000000
+#endif
+
 #define NATIVE_CLASSNAME "io/netty5/incubator/channel/uring/Native"
 #define STATICALLY_CLASSNAME "io/netty5/incubator/channel/uring/NativeStaticallyReferencedJniMethods"
 #define LIBRARYNAME "netty5_transport_native_io_uring"


### PR DESCRIPTION
Motivation:
Looks like older kernels do not have MSG_FASTOPEN. We should still be able to compile on such kernels, even if io_uring won't work there.

Modification:
Define MSG_FASTOPEN if it isn't already.

Result:
We can compile on older kernels that don't have MSG_FASTOPEN.