### PR TITLE
Upgrade to latest netty and netty-tcnative versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,8 +77,8 @@
 
     <checkstyle.version>8.38</checkstyle.version>
     <junit.version>5.9.0</junit.version>
-    <netty.version>4.1.85.Final</netty.version>
-    <netty-tcnative-boringssl-static.version>2.0.54.Final</netty-tcnative-boringssl-static.version>
+    <netty.version>4.1.87.Final</netty.version>
+    <netty-tcnative-boringssl-static.version>2.0.56.Final</netty-tcnative-boringssl-static.version>
     <bouncycastle.version>1.68</bouncycastle.version>
     <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
     <maven-bundle-plugin.version>5.1.1</maven-bundle-plugin.version>


### PR DESCRIPTION
Motivation:

We should depend on the latest releases of netty and netty-tcnative

Modifications:

Upgrade dependencies

Result:

Use latest releases