### PR TITLE
Add support for client / server side TCP_FAST_OPEN

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUring.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUring.java
@@ -15,6 +15,7 @@
  */
 package io.netty.incubator.channel.uring;
 
+import io.netty.channel.ChannelOption;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SystemPropertyUtil;
 
@@ -59,6 +60,26 @@ public final class IOUring {
 
     public static boolean isAvailable() {
         return UNAVAILABILITY_CAUSE == null;
+    }
+
+    /**
+     * Returns {@code true} if the epoll native transport is both {@linkplain #isAvailable() available} and supports
+     * {@linkplain ChannelOption#TCP_FASTOPEN_CONNECT client-side TCP FastOpen}.
+     *
+     * @return {@code true} if it's possible to use client-side TCP FastOpen via io_uring, otherwise {@code false}.
+     */
+    public static boolean isTcpFastOpenClientSideAvailable() {
+        return isAvailable() && Native.IS_SUPPORTING_TCP_FASTOPEN_CLIENT;
+    }
+
+    /**
+     * Returns {@code true} if the epoll native transport is both {@linkplain #isAvailable() available} and supports
+     * {@linkplain ChannelOption#TCP_FASTOPEN server-side TCP FastOpen}.
+     *
+     * @return {@code true} if it's possible to use server-side TCP FastOpen via io_uring, otherwise {@code false}.
+     */
+    public static boolean isTcpFastOpenServerSideAvailable() {
+        return isAvailable() && Native.IS_SUPPORTING_TCP_FASTOPEN_SERVER;
     }
 
     public static void ensureAvailability() {

--- a/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUringChannelOption.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUringChannelOption.java
@@ -35,8 +35,12 @@ public class IOUringChannelOption<T> extends UnixChannelOption<T> {
     public static final ChannelOption<Boolean> IP_TRANSPARENT = valueOf("IP_TRANSPARENT");
     public static final ChannelOption<Boolean> IP_RECVORIGDSTADDR = valueOf("IP_RECVORIGDSTADDR");
     public static final ChannelOption<Integer> TCP_FASTOPEN = valueOf(IOUringChannelOption.class, "TCP_FASTOPEN");
-    public static final ChannelOption<Boolean> TCP_FASTOPEN_CONNECT =
-            valueOf(IOUringChannelOption.class, "TCP_FASTOPEN_CONNECT");
+
+    /**
+     * @deprecated Use {@link ChannelOption#TCP_FASTOPEN} instead.
+     */
+    @Deprecated
+    public static final ChannelOption<Boolean> TCP_FASTOPEN_CONNECT = ChannelOption.TCP_FASTOPEN_CONNECT;
     public static final ChannelOption<Integer> TCP_DEFER_ACCEPT =
             ChannelOption.valueOf(IOUringChannelOption.class, "TCP_DEFER_ACCEPT");
     public static final ChannelOption<Boolean> TCP_QUICKACK = valueOf(IOUringChannelOption.class, "TCP_QUICKACK");

--- a/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUringChannelOption.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUringChannelOption.java
@@ -34,10 +34,14 @@ public class IOUringChannelOption<T> extends UnixChannelOption<T> {
     public static final ChannelOption<Boolean> IP_FREEBIND = valueOf("IP_FREEBIND");
     public static final ChannelOption<Boolean> IP_TRANSPARENT = valueOf("IP_TRANSPARENT");
     public static final ChannelOption<Boolean> IP_RECVORIGDSTADDR = valueOf("IP_RECVORIGDSTADDR");
-    public static final ChannelOption<Integer> TCP_FASTOPEN = valueOf(IOUringChannelOption.class, "TCP_FASTOPEN");
 
     /**
      * @deprecated Use {@link ChannelOption#TCP_FASTOPEN} instead.
+     */
+    public static final ChannelOption<Integer> TCP_FASTOPEN = ChannelOption.TCP_FASTOPEN;
+
+    /**
+     * @deprecated Use {@link ChannelOption#TCP_FASTOPEN_CONNECT} instead.
      */
     @Deprecated
     public static final ChannelOption<Boolean> TCP_FASTOPEN_CONNECT = ChannelOption.TCP_FASTOPEN_CONNECT;

--- a/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUringServerSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUringServerSocketChannel.java
@@ -62,6 +62,12 @@ public final class IOUringServerSocketChannel extends AbstractIOUringServerChann
     @Override
     public void doBind(SocketAddress localAddress) throws Exception {
         super.doBind(localAddress);
+        if (IOUring.isTcpFastOpenServerSideAvailable()) {
+            int fastOpen = config().getTcpFastopen();
+            if (fastOpen > 0) {
+                socket.setTcpFastOpen(fastOpen);
+            }
+        }
         socket.listen(config.getBacklog());
         active = true;
     }

--- a/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUringSubmissionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUringSubmissionQueue.java
@@ -178,9 +178,13 @@ final class IOUringSubmissionQueue {
     }
 
     boolean addSendmsg(int fd, long msgHdr, short extraData) {
+        return addSendmsg(fd, msgHdr, 0, extraData);
+    }
+
+    boolean addSendmsg(int fd, long msgHdr, int flags, short extraData) {
         // Use Native.MSG_DONTWAIT due a io_uring bug which did have it not respect non-blocking fds.
         // see https://lore.kernel.org/io-uring/371592A7-A199-4F5C-A906-226FFC6CEED9@googlemail.com/T/#u
-        return enqueueSqe(Native.IORING_OP_SENDMSG, flags(), Native.MSG_DONTWAIT, fd, msgHdr, 1, 0, extraData);
+        return enqueueSqe(Native.IORING_OP_SENDMSG, flags(), Native.MSG_DONTWAIT | flags, fd, msgHdr, 1, 0, extraData);
     }
 
     boolean addRead(int fd, long bufferAddress, int pos, int limit, short extraData) {

--- a/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/NativeStaticallyReferencedJniMethods.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/NativeStaticallyReferencedJniMethods.java
@@ -78,6 +78,8 @@ final class NativeStaticallyReferencedJniMethods {
     static native int ioringEnterGetevents();
     static native int iosqeAsync();
     static native int msgDontwait();
+    static native int msgFastopen();
+
     static native int cmsgSpace();
     static native int cmsgLen();
     static native int solUdp();

--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -52,6 +52,11 @@
 #define UDP_SEGMENT 103
 #endif
 
+// MSG_FASTOPEN is defined in linux 3.6. We define this here so older kernels can compile.
+#ifndef MSG_FASTOPEN
+#define MSG_FASTOPEN 0x20000000
+#endif
+
 // Add define if NETTY_IO_URING_BUILD_STATIC is defined so it is picked up in netty_jni_util.c
 #ifdef NETTY_IO_URING_BUILD_STATIC
 #define NETTY_JNI_UTIL_BUILD_STATIC
@@ -522,6 +527,10 @@ static jint netty_io_uring_msgDontwait(JNIEnv* env, jclass clazz) {
     return MSG_DONTWAIT;
 }
 
+static jint netty_io_uring_msgFastopen(JNIEnv* env, jclass clazz) {
+    return MSG_FASTOPEN;
+}
+
 static jint netty_io_uring_cmsgSpace(JNIEnv* env, jclass clazz) {
     return CMSG_SPACE(sizeof(uint16_t));
 }
@@ -590,6 +599,7 @@ static const JNINativeMethod statically_referenced_fixed_method_table[] = {
   { "ioringEnterGetevents", "()I", (void *) netty_io_uring_ioringEnterGetevents },
   { "iosqeAsync", "()I", (void *) netty_io_uring_iosqeAsync },
   { "msgDontwait", "()I", (void *) netty_io_uring_msgDontwait },
+  { "msgFastopen", "()I", (void *) netty_io_uring_msgFastopen },
   { "solUdp", "()I", (void *) netty_io_uring_solUdp },
   { "udpSegment", "()I", (void *) netty_io_uring_udpSegment },
   { "cmsghdrOffsetofCmsgLen", "()I", (void *) netty_io_uring_cmsghdrOffsetofCmsgLen },

--- a/transport-native-io_uring/src/test/java/io/netty/incubator/channel/uring/IOUringSocketTestPermutation.java
+++ b/transport-native-io_uring/src/test/java/io/netty/incubator/channel/uring/IOUringSocketTestPermutation.java
@@ -19,6 +19,7 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFactory;
+import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.channel.socket.nio.NioDatagramChannel;
@@ -32,11 +33,6 @@ import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -73,7 +69,7 @@ public class IOUringSocketTestPermutation extends SocketTestPermutation {
                                             .channel(IOUringServerSocketChannel.class);
             }
         });
-        if (isServerFastOpen()) {
+        if (IOUring.isTcpFastOpenServerSideAvailable()) {
             toReturn.add(new BootstrapFactory<ServerBootstrap>() {
                 @Override
                 public ServerBootstrap newInstance() {
@@ -112,6 +108,25 @@ public class IOUringSocketTestPermutation extends SocketTestPermutation {
                     }
                 }
         );
+    }
+
+
+    @Override
+    public List<BootstrapFactory<Bootstrap>> clientSocketWithFastOpen() {
+        List<BootstrapFactory<Bootstrap>> factories = clientSocket();
+
+        if (IOUring.isTcpFastOpenClientSideAvailable()) {
+            int insertIndex = factories.size() - 1; // Keep NIO fixture last.
+            factories.add(insertIndex, new BootstrapFactory<Bootstrap>() {
+                @Override
+                public Bootstrap newInstance() {
+                    return new Bootstrap().group(IO_URING_WORKER_GROUP).channel(IOUringSocketChannel.class)
+                            .option(ChannelOption.TCP_FASTOPEN_CONNECT, true);
+                }
+            });
+        }
+
+        return factories;
     }
 
     @Override
@@ -155,40 +170,5 @@ public class IOUringSocketTestPermutation extends SocketTestPermutation {
         );
 
         return combo(bfs, bfs);
-    }
-
-    public boolean isServerFastOpen() {
-        return AccessController.doPrivileged(new PrivilegedAction<Integer>() {
-            @Override
-            public Integer run() {
-                int fastopen = 0;
-                File file = new File("/proc/sys/net/ipv4/tcp_fastopen");
-                if (file.exists()) {
-                    BufferedReader in = null;
-                    try {
-                        in = new BufferedReader(new FileReader(file));
-                        fastopen = Integer.parseInt(in.readLine());
-                        if (logger.isDebugEnabled()) {
-                            logger.debug("{}: {}", file, fastopen);
-                        }
-                    } catch (Exception e) {
-                        logger.debug("Failed to get TCP_FASTOPEN from: {}", file, e);
-                    } finally {
-                        if (in != null) {
-                            try {
-                                in.close();
-                            } catch (Exception e) {
-                                // Ignored.
-                            }
-                        }
-                    }
-                } else {
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("{}: {} (non-existent)", file, fastopen);
-                    }
-                }
-                return fastopen;
-            }
-        }) == 3;
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/incubator/channel/uring/IOUringSocketTestPermutation.java
+++ b/transport-native-io_uring/src/test/java/io/netty/incubator/channel/uring/IOUringSocketTestPermutation.java
@@ -30,8 +30,6 @@ import io.netty.testsuite.transport.TestsuitePermutation.BootstrapComboFactory;
 import io.netty.testsuite.transport.TestsuitePermutation.BootstrapFactory;
 import io.netty.testsuite.transport.socket.SocketTestPermutation;
 import io.netty.util.concurrent.DefaultThreadFactory;
-import io.netty.util.internal.logging.InternalLogger;
-import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -45,8 +43,6 @@ public class IOUringSocketTestPermutation extends SocketTestPermutation {
             new IOUringEventLoopGroup(BOSSES, new DefaultThreadFactory("testsuite-io_uring-boss", true));
     static final EventLoopGroup IO_URING_WORKER_GROUP =
             new IOUringEventLoopGroup(WORKERS, new DefaultThreadFactory("testsuite-io_uring-worker", true));
-
-    private static final InternalLogger logger = InternalLoggerFactory.getInstance(IOUringSocketTestPermutation.class);
 
     @Override
     public List<BootstrapComboFactory<ServerBootstrap, Bootstrap>> socket() {
@@ -76,7 +72,7 @@ public class IOUringSocketTestPermutation extends SocketTestPermutation {
                     ServerBootstrap serverBootstrap = new ServerBootstrap().group(IO_URING_BOSS_GROUP,
                                                                                   IO_URING_WORKER_GROUP)
                                                                            .channel(IOUringServerSocketChannel.class);
-                    serverBootstrap.option(IOUringChannelOption.TCP_FASTOPEN, 5);
+                    serverBootstrap.option(ChannelOption.TCP_FASTOPEN, 5);
                     return serverBootstrap;
                 }
             });


### PR DESCRIPTION
Motivation:

We support TCP_FAST_OPEN in our other transports so we should also support it when using io_uring

Modifications:

Add code to support TCP_FAST_OPEN to be on-par with other transports

Result:

Support TCP_FAST_OPEN for server and client side when using io_uring