### PR TITLE
Make submissionqueue enqueueSqe method package private.

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUringSubmissionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUringSubmissionQueue.java
@@ -110,8 +110,8 @@ final class IOUringSubmissionQueue {
         return numHandledFds < iosqeAsyncThreshold ? 0 : Native.IOSQE_ASYNC;
     }
 
-    private boolean enqueueSqe(byte op, int flags, int rwFlags, int fd,
-                               long bufferAddress, int length, long offset, short data) {
+    boolean enqueueSqe(byte op, int flags, int rwFlags, int fd,
+                       long bufferAddress, int length, long offset, short data) {
         int pending = tail - head;
         boolean submit = pending == ringEntries;
         if (submit) {


### PR DESCRIPTION
Currently it isn't possible to test the IORING_OP_NOP because the enqueSqe method is private. This PR fixes that by making it package private.