### PR TITLE
Replace stdlib write/read with send/recv

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/AbstractIOUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/AbstractIOUringStreamChannel.java
@@ -238,8 +238,8 @@ abstract class AbstractIOUringStreamChannel extends AbstractIOUringChannel imple
             assert iovArray == null;
             ByteBuf buf = (ByteBuf) msg;
             IOUringSubmissionQueue submissionQueue = submissionQueue();
-            submissionQueue.addWrite(socket.intValue(), buf.memoryAddress(), buf.readerIndex(),
-                    buf.writerIndex(), (short) 0);
+            submissionQueue.addSend(socket.intValue(), buf.memoryAddress(), buf.readerIndex(),
+                                    buf.writerIndex(), (short) 0);
             return 1;
         }
 
@@ -254,8 +254,8 @@ abstract class AbstractIOUringStreamChannel extends AbstractIOUringChannel imple
 
             readBuffer = byteBuf;
 
-            submissionQueue.addRead(socket.intValue(), byteBuf.memoryAddress(),
-                    byteBuf.writerIndex(), byteBuf.capacity(), (short) 0);
+            submissionQueue.addRecv(socket.intValue(), byteBuf.memoryAddress(),
+                                    byteBuf.writerIndex(), byteBuf.capacity(), (short) 0);
             return 1;
         }
 

--- a/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUringDatagramChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUringDatagramChannel.java
@@ -493,8 +493,8 @@ public final class IOUringDatagramChannel extends AbstractIOUringChannel impleme
             int numDatagram = datagramSize == 0 ? 1 : Math.max(1, byteBuf.writableBytes() / datagramSize);
 
             if (isConnected() && numDatagram <= 1) {
-                submissionQueue().addRead(socket.intValue(), byteBuf.memoryAddress(),
-                        byteBuf.writerIndex(), byteBuf.capacity(), (short) -1);
+                submissionQueue().addRecv(socket.intValue(), byteBuf.memoryAddress(),
+                                          byteBuf.writerIndex(), byteBuf.capacity(), (short) -1);
                 return 1;
             } else {
                 int scheduled = scheduleRecvmsg(byteBuf, numDatagram, datagramSize);
@@ -623,8 +623,8 @@ public final class IOUringDatagramChannel extends AbstractIOUringChannel impleme
                             IOUringDatagramChannel.this.remoteAddress(),
                             bufferAddress, data.readableBytes(), segmentSize);
                 }
-                submissionQueue.addWrite(socket.intValue(), bufferAddress, data.readerIndex(),
-                        data.writerIndex(), (short) -1);
+                submissionQueue.addSend(socket.intValue(), bufferAddress, data.readerIndex(),
+                                        data.writerIndex(), (short) -1);
                 return true;
             }
             return scheduleSendmsg(remoteAddress, bufferAddress, data.readableBytes(), segmentSize);

--- a/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUringEventLoop.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUringEventLoop.java
@@ -251,10 +251,11 @@ public final class IOUringEventLoop extends SingleThreadEventLoop {
             if (channel == null) {
                 return;
             }
-            if (op == Native.IORING_OP_RECV || op == Native.IORING_OP_ACCEPT || op == Native.IORING_OP_RECVMSG) {
+            if (op == Native.IORING_OP_RECV || op == Native.IORING_OP_ACCEPT || op == Native.IORING_OP_RECVMSG ||
+               op == Native.IORING_OP_READ) {
                 handleRead(channel, res, data);
             } else if (op == Native.IORING_OP_WRITEV ||
-                    op == Native.IORING_OP_SEND || op == Native.IORING_OP_SENDMSG) {
+                    op == Native.IORING_OP_SEND || op == Native.IORING_OP_SENDMSG || op == Native.IORING_OP_WRITE) {
                 handleWrite(channel, res, data);
             } else if (op == Native.IORING_OP_POLL_ADD) {
                 handlePollAdd(channel, res, data);

--- a/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUringEventLoop.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUringEventLoop.java
@@ -251,10 +251,10 @@ public final class IOUringEventLoop extends SingleThreadEventLoop {
             if (channel == null) {
                 return;
             }
-            if (op == Native.IORING_OP_READ || op == Native.IORING_OP_ACCEPT || op == Native.IORING_OP_RECVMSG) {
+            if (op == Native.IORING_OP_RECV || op == Native.IORING_OP_ACCEPT || op == Native.IORING_OP_RECVMSG) {
                 handleRead(channel, res, data);
             } else if (op == Native.IORING_OP_WRITEV ||
-                    op == Native.IORING_OP_WRITE || op == Native.IORING_OP_SENDMSG) {
+                    op == Native.IORING_OP_SEND || op == Native.IORING_OP_SENDMSG) {
                 handleWrite(channel, res, data);
             } else if (op == Native.IORING_OP_POLL_ADD) {
                 handlePollAdd(channel, res, data);

--- a/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUringSubmissionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUringSubmissionQueue.java
@@ -199,6 +199,14 @@ final class IOUringSubmissionQueue {
         return enqueueSqe(Native.IORING_OP_WRITE, flags(), 0, fd, bufferAddress + pos, limit - pos, 0, extraData);
     }
 
+    boolean addRecv(int fd, long bufferAddress, int pos, int limit, short extraData) {
+        return enqueueSqe(Native.IORING_OP_RECV, flags(), 0, fd, bufferAddress + pos, limit - pos, 0, extraData);
+    }
+
+    boolean addSend(int fd, long bufferAddress, int pos, int limit, short extraData) {
+        return enqueueSqe(Native.IORING_OP_SEND, flags(), 0, fd, bufferAddress + pos, limit - pos, 0, extraData);
+    }
+
     boolean addAccept(int fd, long address, long addressLength, short extraData) {
         return enqueueSqe(Native.IORING_OP_ACCEPT, flags(), Native.SOCK_NONBLOCK | Native.SOCK_CLOEXEC, fd,
                 address, 0, addressLength, extraData);

--- a/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/Native.java
@@ -143,6 +143,8 @@ final class Native {
     static final byte IORING_OP_ACCEPT = NativeStaticallyReferencedJniMethods.ioringOpAccept();
     static final byte IORING_OP_READ = NativeStaticallyReferencedJniMethods.ioringOpRead();
     static final byte IORING_OP_WRITE = NativeStaticallyReferencedJniMethods.ioringOpWrite();
+    static final byte IORING_OP_RECV = NativeStaticallyReferencedJniMethods.ioringOpRecv();
+    static final byte IORING_OP_SEND = NativeStaticallyReferencedJniMethods.ioringOpSend();
     static final byte IORING_OP_POLL_REMOVE = NativeStaticallyReferencedJniMethods.ioringOpPollRemove();
     static final byte IORING_OP_CONNECT = NativeStaticallyReferencedJniMethods.ioringOpConnect();
     static final byte IORING_OP_CLOSE = NativeStaticallyReferencedJniMethods.ioringOpClose();
@@ -164,6 +166,8 @@ final class Native {
             IORING_OP_ACCEPT,
             IORING_OP_READ,
             IORING_OP_WRITE,
+            IORING_OP_RECV,
+            IORING_OP_SEND,
             IORING_OP_POLL_REMOVE,
             IORING_OP_CONNECT,
             IORING_OP_CLOSE,

--- a/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/NativeStaticallyReferencedJniMethods.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/NativeStaticallyReferencedJniMethods.java
@@ -71,6 +71,8 @@ final class NativeStaticallyReferencedJniMethods {
     static native byte ioringOpAccept();
     static native byte ioringOpRead();
     static native byte ioringOpWrite();
+    static native byte ioringOpRecv();
+    static native byte ioringOpSend();
     static native byte ioringOpConnect();
     static native byte ioringOpClose();
     static native byte ioringOpSendmsg();

--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -499,6 +499,14 @@ static jbyte netty_io_uring_ioringOpWrite(JNIEnv* env, jclass clazz) {
     return IORING_OP_WRITE;
 }
 
+static jbyte netty_io_uring_ioringOpRecv(JNIEnv* env, jclass clazz) {
+    return IORING_OP_RECV;
+}
+
+static jbyte netty_io_uring_ioringOpSend(JNIEnv* env, jclass clazz) {
+    return IORING_OP_SEND;
+}
+
 static jbyte netty_io_uring_ioringOpConnect(JNIEnv* env, jclass clazz) {
     return IORING_OP_CONNECT;
 }
@@ -592,6 +600,8 @@ static const JNINativeMethod statically_referenced_fixed_method_table[] = {
   { "ioringOpAccept", "()B", (void *) netty_io_uring_ioringOpAccept },
   { "ioringOpRead", "()B", (void *) netty_io_uring_ioringOpRead },
   { "ioringOpWrite", "()B", (void *) netty_io_uring_ioringOpWrite },
+  { "ioringOpRecv", "()B", (void *) netty_io_uring_ioringOpRecv },
+  { "ioringOpSend", "()B", (void *) netty_io_uring_ioringOpSend },
   { "ioringOpConnect", "()B", (void *) netty_io_uring_ioringOpConnect },
   { "ioringOpClose", "()B", (void *) netty_io_uring_ioringOpClose },
   { "ioringOpSendmsg", "()B", (void *) netty_io_uring_ioringOpSendmsg },

--- a/transport-native-io_uring/src/test/java/io/netty/incubator/channel/uring/NativeTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/incubator/channel/uring/NativeTest.java
@@ -17,7 +17,6 @@ package io.netty.incubator.channel.uring;
 
 import io.netty.channel.unix.FileDescriptor;
 
-import java.io.File;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.concurrent.CountDownLatch;
@@ -67,7 +66,7 @@ public class NativeTest {
         assertNotNull(completionQueue);
 
         assertFalse(submissionQueue.addWrite(fd, writeEventByteBuf.memoryAddress(),
-                writeEventByteBuf.readerIndex(), writeEventByteBuf.writerIndex(), (short) 0));
+                                            writeEventByteBuf.readerIndex(), writeEventByteBuf.writerIndex(), (short) 0));
         submissionQueue.submit();
 
         completionQueue.ioUringWaitCqe();
@@ -81,7 +80,7 @@ public class NativeTest {
 
         final ByteBuf readEventByteBuf = allocator.directBuffer(100);
         assertFalse(submissionQueue.addRead(fd, readEventByteBuf.memoryAddress(),
-                                           readEventByteBuf.writerIndex(), readEventByteBuf.capacity(), (short) 0));
+                                            readEventByteBuf.writerIndex(), readEventByteBuf.capacity(), (short) 0));
         submissionQueue.submit();
 
         completionQueue.ioUringWaitCqe();
@@ -293,7 +292,7 @@ public class NativeTest {
         try {
             // Ensure userdata works with negative and positive values
             for (int i = Short.MIN_VALUE; i <= Short.MAX_VALUE; i++) {
-                submissionQueue.addWrite(-1, -1, -1, -1, (short) i);
+                submissionQueue.addSend(-1, -1, -1, -1, (short) i);
                 assertEquals(1, submissionQueue.submitAndWait());
                 final int expectedData = i;
                 assertEquals(1, completionQueue.process(new IOUringCompletionQueueCallback() {
@@ -301,7 +300,7 @@ public class NativeTest {
                     public void handle(int fd, int res, int flags, byte op, short data) {
                         assertEquals(-1, fd);
                         assertTrue(res < 0);
-                        assertEquals(Native.IORING_OP_WRITE, op);
+                        assertEquals(Native.IORING_OP_SEND, op);
                         assertEquals(expectedData, data);
                     }
                 }));


### PR DESCRIPTION
Motivation:

Recv/Send paths are more suited for socket fds

Modifications:

Replace existing READ/WRITE OP usages with RECV/SEND

Result:

Better performance