### PR TITLE
Bump up os-maven-plugin to 1.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-    <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
+    <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
   </properties>
 
   <build>


### PR DESCRIPTION
Motivation:

os-maven-plugin 1.7.0 does not recognize LoongArch information, os-maven-plugin supports LoongArch since 1.7.1

Modification:

Update pom.xml

Result:

LoongArch cpu information can be correctly identified