### PR TITLE
Ignore POLL_REMOVE CQEs on opened fd (Fixes #194)

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUringEventLoop.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUringEventLoop.java
@@ -265,11 +265,17 @@ public final class IOUringEventLoop extends SingleThreadEventLoop {
                 } else if (res == 0) {
                     logger.trace("IORING_POLL_REMOVE successful");
                 }
-                channel.clearPollFlag(data);
-                if (!channel.ioScheduled()) {
-                    // We cancelled the POLL ops which means we are done and should remove the mapping.
-                    remove(channel);
-                    return;
+                // fd reuse can replace a closed channel (with pending POLL_REMOVE CQEs)
+                // with a new one: better not making it to mess-up with its state!
+                if (!channel.isOpen()) {
+                    channel.clearPollFlag(data);
+                    if (!channel.ioScheduled()) {
+                        // We cancelled the POLL ops which means we are done and should remove the mapping.
+                        remove(channel);
+                        return;
+                    }
+                } else {
+                    logger.trace("IGNORING IORING_POLL_REMOVE on not closed fd");
                 }
             } else if (op == Native.IORING_OP_CONNECT) {
                 handleConnect(channel, res);

--- a/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUringEventLoop.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUringEventLoop.java
@@ -275,7 +275,9 @@ public final class IOUringEventLoop extends SingleThreadEventLoop {
                         return;
                     }
                 } else {
-                    logger.trace("IGNORING IORING_POLL_REMOVE on not closed fd");
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("IGNORING IORING_POLL_REMOVE on not closed fd = {}", fd);
+                    }
                 }
             } else if (op == Native.IORING_OP_CONNECT) {
                 handleConnect(channel, res);


### PR DESCRIPTION
Motivation:
fd reuse can replace a closed channel, still awaiting POLL_REMOVE CQEs, with a new one that will handle them, causing its removal from the map of handled channels.

Modification:
POLL_REMOVE CQEs are handled only by (marked) closed fds. Opened one, will just ignore them.

Result:
No still opened (reused) fds can be removed due to a late POLL_REMOVE completion arrival.