### PR TITLE
Correctly signal successful connect when TCP_FAST_OPEN was used and i…

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/AbstractIOUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/AbstractIOUringChannel.java
@@ -605,7 +605,9 @@ abstract class AbstractIOUringChannel extends AbstractChannel implements UnixCha
                 if (res > 0) {
                     // Connect complete!
                     outboundBuffer().removeBytes(res);
-                    connectComplete(res);
+
+                    // Explicit pass in 0 as this is returned by a connect(...) call when it was successful.
+                    connectComplete(0);
                 } else if (res == ERRNO_EINPROGRESS_NEGATIVE || res == 0) {
                     // This happens when we (as a client) have no pre-existing cookie for doing a fast-open connection.
                     // In this case, our TCP connection will be established normally, but no data was transmitted at this time.


### PR DESCRIPTION
…t was succesful

Motivation:

We had a bug which could lead to reporting connect failures when TCP_FAST_OPEN was used even tho the establishment of the the connection was acutally succesful.

Modifications:

Pass the correct value to connectComplete(...) on success.

Result:

No more failures when using TCP_FAST_OPEN