### PR TITLE
Upgrade to latest maven version and use sdkman to install it

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/apache-maven/3.9.0/apache-maven-3.9.0-bin.zip
+distributionUrl=https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/apache-maven/3.9.1/apache-maven-3.9.1-bin.zip

--- a/docker/Dockerfile.centos6
+++ b/docker/Dockerfile.centos6
@@ -1,5 +1,7 @@
 FROM centos:6.10
 
+ENV MAVEN_VERSION 3.9.1
+
 # Update as we need to use the vault now.
 RUN sed -i -e 's/^mirrorlist/#mirrorlist/g' -e 's/^#baseurl=http:\/\/mirror.centos.org\/centos\/$releasever\//baseurl=https:\/\/linuxsoft.cern.ch\/centos-vault\/\/6.10\//g' /etc/yum.repos.d/CentOS-Base.repo
 
@@ -27,16 +29,13 @@ ENV JAVA_VERSION $java_version
 # Installing Java removing some unnecessary SDKMAN files
 RUN bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && \
     yes | sdk install java $JAVA_VERSION && \
+    yes | sdk install maven $MAVEN_VERSION && \
     rm -rf $HOME/.sdkman/archives/* && \
     rm -rf $HOME/.sdkman/tmp/*"
 
 RUN echo 'export JAVA_HOME="/root/.sdkman/candidates/java/current"' >> ~/.bashrc
 RUN echo 'PATH=/root/.sdkman/candidates/java/current/bin:$PATH' >> ~/.bashrc
 
-WORKDIR /opt
-RUN curl https://dlcdn.apache.org/maven/maven-3/3.9.0/binaries/apache-maven-3.9.0-bin.tar.gz | tar -xz
-RUN echo 'PATH=/opt/apache-maven-3.9.0/bin/:$PATH' >> ~/.bashrc
-
 # Prepare our own build
-ENV PATH /opt/apache-maven-3.9.0/bin/:$PATH
+ENV PATH /root/.sdkman/candidates/maven/current:$PATH
 ENV JAVA_HOME /root/.sdkman/candidates/java/current/

--- a/docker/Dockerfile.centos7
+++ b/docker/Dockerfile.centos7
@@ -2,6 +2,7 @@ FROM centos:7.9.2009
 
 ARG gcc_version=10.2-2020.11
 ENV GCC_VERSION $gcc_version
+ENV MAVEN_VERSION 3.9.1
 
 # Install requirements
 RUN yum install -y \
@@ -30,6 +31,7 @@ ENV JAVA_VERSION $java_version
 # Installing Java removing some unnecessary SDKMAN files
 RUN bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && \
     yes | sdk install java $JAVA_VERSION && \
+    yes | sdk install maven $MAVEN_VERSION && \
     rm -rf $HOME/.sdkman/archives/* && \
     rm -rf $HOME/.sdkman/tmp/*"
 
@@ -48,5 +50,5 @@ RUN curl https://dlcdn.apache.org/maven/maven-3/3.9.0/binaries/apache-maven-3.9.
 RUN echo 'PATH=/opt/apache-maven-3.9.0/bin/:$PATH' >> ~/.bashrc
 
 # Prepare our own build
-ENV PATH /opt/apache-maven-3.9.0/bin/:$PATH
+ENV PATH /root/.sdkman/candidates/maven/current:$PATH
 ENV JAVA_HOME /root/.sdkman/candidates/java/current/

--- a/docker/Dockerfile.centos7arm64v8
+++ b/docker/Dockerfile.centos7arm64v8
@@ -1,5 +1,7 @@
 FROM arm64v8/centos:7.9.2009
 
+ENV MAVEN_VERSION 3.9.1
+
 # Install requirements
 RUN yum install -y \
 	apr-devel \
@@ -27,18 +29,13 @@ ENV JAVA_VERSION $java_version
 # Installing Java removing some unnecessary SDKMAN files
 RUN bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && \
     yes | sdk install java $JAVA_VERSION && \
+    yes | sdk install maven $MAVEN_VERSION && \
     rm -rf $HOME/.sdkman/archives/* && \
     rm -rf $HOME/.sdkman/tmp/*"
 
 RUN echo 'export JAVA_HOME="/root/.sdkman/candidates/java/current"' >> ~/.bashrc
 RUN echo 'PATH=/root/.sdkman/candidates/java/current/bin:$PATH' >> ~/.bashrc
 
-WORKDIR /opt
-
-# Install maven
-RUN curl https://dlcdn.apache.org/maven/maven-3/3.9.0/binaries/apache-maven-3.9.0-bin.tar.gz | tar -xz
-RUN echo 'PATH=/opt/apache-maven-3.9.0/bin/:$PATH' >> ~/.bashrc
-
 # Prepare our own build
-ENV PATH /opt/apache-maven-3.9.0/bin/:$PATH
+ENV PATH /root/.sdkman/candidates/maven/current:$PATH
 ENV JAVA_HOME /root/.sdkman/candidates/java/current/


### PR DESCRIPTION
Motivation:

There was a new maven release we should use. Also just use sdkman to do so.

Modifications:

- Upgrade to maven 3.9.1
- Use sdkman

Result:

Use latest maven version and use sdkman