### PR TITLE
Upgrade to netty 4.1.91.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
 
     <checkstyle.version>8.38</checkstyle.version>
     <junit.version>5.9.0</junit.version>
-    <netty.version>4.1.89.Final</netty.version>
+    <netty.version>4.1.91.Final</netty.version>
     <netty-tcnative-boringssl-static.version>2.0.59.Final</netty-tcnative-boringssl-static.version>
     <bouncycastle.version>1.68</bouncycastle.version>
     <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>


### PR DESCRIPTION
Motivation:

A new netty version was released today.

Modifications:

Upgrade to latest netty version

Result:

Up-to-date