### PR TITLE
Upgrade netty and netty-tcnative to latest releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,8 +77,8 @@
 
     <checkstyle.version>8.38</checkstyle.version>
     <junit.version>5.9.0</junit.version>
-    <netty.version>4.1.91.Final</netty.version>
-    <netty-tcnative-boringssl-static.version>2.0.59.Final</netty-tcnative-boringssl-static.version>
+    <netty.version>4.1.92.Final</netty.version>
+    <netty-tcnative-boringssl-static.version>2.0.60.Final</netty-tcnative-boringssl-static.version>
     <bouncycastle.version>1.68</bouncycastle.version>
     <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
     <maven-bundle-plugin.version>5.1.1</maven-bundle-plugin.version>


### PR DESCRIPTION
Motivation:

There was a new release of netty and netty-tcnative

Modifications:

Use latest releases

Result:

Up to date dependencies