### PR TITLE
Upgrade to netty 4.1.94.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
 
     <checkstyle.version>8.38</checkstyle.version>
     <junit.version>5.9.0</junit.version>
-    <netty.version>4.1.93.Final</netty.version>
+    <netty.version>4.1.94.Final</netty.version>
     <netty-tcnative-boringssl-static.version>2.0.61.Final</netty-tcnative-boringssl-static.version>
     <bouncycastle.version>1.68</bouncycastle.version>
     <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>


### PR DESCRIPTION
Motivation:

A new version of netty is out

Modifications:

Upgrade to 4.1.94.Final

Result:

Use latest netty version