### PR TITLE
Update workflows to make things more robust when it comes to caching

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -47,6 +47,7 @@ jobs:
 
       # Cache .m2/repository
       - uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: ~/.m2/repository
           key: build-${{ matrix.setup }}-cache-m2-repository-${{ hashFiles('**/pom.xml') }}
@@ -54,7 +55,7 @@ jobs:
             build-${{ matrix.setup }}-cache-m2-repository-
 
       # Enable caching of Docker layers
-      - uses: satackey/action-docker-layer-caching@v0.0.11
+      - uses: jpribyl/action-docker-layer-caching@v0.1.1
         continue-on-error: true
         with:
           key: build-${{ matrix.setup }}-docker-cache-{hash}

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -46,6 +46,7 @@ jobs:
 
       # Cache .m2/repository
       - uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: ~/.m2/repository
           key: stage-snapshot-${{ matrix.setup }}-cache-m2-repository-${{ hashFiles('**/pom.xml') }}
@@ -53,7 +54,7 @@ jobs:
             stage-snapshot-${{ matrix.setup }}-cache-m2-repository-
 
       # Enable caching of Docker layers
-      - uses: satackey/action-docker-layer-caching@v0.0.11
+      - uses: jpribyl/action-docker-layer-caching@v0.1.1
         env:
           docker-cache-name: staging-${{ matrix.setup }}-cache-docker
         continue-on-error: true
@@ -92,6 +93,7 @@ jobs:
 
       # Cache .m2/repository
       - uses: actions/cache@v3
+        continue-on-error: true
         env:
           cache-name: deploy-staging-cache-m2-repository
         with:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -38,6 +38,7 @@ jobs:
 
       # Cache .m2/repository
       - uses: actions/cache@v3
+        continue-on-error: true
         env:
           cache-name: verify-cache-m2-repository
         with:
@@ -68,6 +69,7 @@ jobs:
 
       # Cache .m2/repository
       - uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: ~/.m2/repository
           key: build-pr-${{ matrix.setup }}-cache-m2-repository-${{ hashFiles('**/pom.xml') }}
@@ -75,7 +77,7 @@ jobs:
             build-pr-${{ matrix.setup }}-cache-m2-repository-
 
       # Enable caching of Docker layers
-      - uses: satackey/action-docker-layer-caching@v0.0.11
+      - uses: jpribyl/action-docker-layer-caching@v0.1.1
         continue-on-error: true
         with:
           key: pr-${{ matrix.setup }}-docker-cache-{hash}
@@ -110,6 +112,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: actions/cache@v3
+        continue-on-error: true
         env:
           cache-name: build-pr-ubuntu-cache
         with:

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -38,6 +38,7 @@ jobs:
 
       # Cache .m2/repository
       - uses: actions/cache@v3
+        continue-on-error: true
         env:
           cache-name: release-cache-m2-repository
         with:
@@ -116,7 +117,7 @@ jobs:
         run: mkdir -p ~/local-staging
 
       # Enable caching of Docker layers
-      - uses: satackey/action-docker-layer-caching@v0.0.11
+      - uses: jpribyl/action-docker-layer-caching@v0.1.1
         env:
           docker-cache-name: staging-${{ matrix.setup }}-cache-docker
         continue-on-error: true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -46,6 +46,7 @@ jobs:
 
     # Cache .m2/repository
     - uses: actions/cache@v3
+      continue-on-error: true
       env:
         cache-name: ${{ matrix.language }}-cache-m2-repository
       with:


### PR DESCRIPTION
Motivation:

When caching fails during workflow execution we should still continue the build as its just an optimization. Also we should use the new fork for docker layer caching

Modifications:

- Update action that does the docker layer caching to the new fork
- Ignore errors during caching

Result:

More stable builds