### PR TITLE
Upgrade maven-settings-action to latest version

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Merge staging repositories
         run: bash ./.github/scripts/merge_local_staging.sh ~/local-staging ~/linux-aarch64-local-staging ~/linux-x86_64-local-staging
 
-      - uses: s4u/maven-settings-action@v2.2.0
+      - uses: s4u/maven-settings-action@v2.8.0
         with:
           servers: |
             [{

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -120,7 +120,7 @@ jobs:
         working-directory: ./prepare-release-workspace/
         run: docker-compose ${{ matrix.docker-compose-build }}
 
-      - uses: s4u/maven-settings-action@v2.2.0
+      - uses: s4u/maven-settings-action@v2.8.0
         with:
           servers: |
             [{
@@ -199,7 +199,7 @@ jobs:
         working-directory: ./prepare-release-workspace/
         run: bash ./.github/scripts/merge_local_staging.sh /home/runner/local-staging/staging ~/linux-aarch64-local-staging/staging ~/linux-x86_64-local-staging/staging
 
-      - uses: s4u/maven-settings-action@v2.2.0
+      - uses: s4u/maven-settings-action@v2.8.0
         with:
           servers: |
             [{


### PR DESCRIPTION
Motivation:

We should use the latest maven-settings-action to fix warnings

Modifications:

Update maven-settings-action to 2.8.0

Result:

No more warnings