### PR TITLE
Use '-Xcheck:jni' during testsuite run to detect JNI bugs

### DIFF
--- a/transport-native-io_uring/pom.xml
+++ b/transport-native-io_uring/pom.xml
@@ -272,7 +272,7 @@
                   </properties>
                   <!-- Ensure the whole stacktrace is preserved when an exception is thrown. See https://issues.apache.org/jira/browse/SUREFIRE-1457 -->
                   <trimStackTrace>false</trimStackTrace>
-                  <argLine>${test.argLine}</argLine>
+                  <argLine>-ea -Xcheck:jni ${test.argLine}</argLine>
                   <!-- Ensure a new JVM is used -->
                   <forkCount>1</forkCount>
                   <reuseForks>false</reuseForks>
@@ -305,7 +305,7 @@
                   </properties>
                   <!-- Ensure the whole stacktrace is preserved when an exception is thrown. See https://issues.apache.org/jira/browse/SUREFIRE-1457 -->
                   <trimStackTrace>false</trimStackTrace>
-                  <argLine>${test.argLine}</argLine>
+                  <argLine>-ea -Xcheck:jni ${test.argLine}</argLine>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
Motivation:

We should run our testsuite with '-Xcheck:jni' to ensure we catch bugs in our JNI code which could later cause issues like crashes

Modifications:

- Add -Xcheck:jni

Result:

Testsuite will be able to catch more JNI bugs