### PR TITLE
Change default value of MAX_MESSAGES_PER_READ to 16 for all Channel i…

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/AbstractIOUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/AbstractIOUringChannel.java
@@ -63,7 +63,7 @@ import static io.netty.util.internal.ObjectUtil.*;
 
 abstract class AbstractIOUringChannel extends AbstractChannel implements UnixChannel {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(AbstractIOUringChannel.class);
-    private static final ChannelMetadata METADATA = new ChannelMetadata(false);
+    private static final ChannelMetadata METADATA = new ChannelMetadata(false, 16);
     final LinuxSocket socket;
     protected volatile boolean active;
 

--- a/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUringDatagramChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUringDatagramChannel.java
@@ -46,7 +46,7 @@ import java.nio.channels.UnresolvedAddressException;
 import static io.netty.channel.unix.Errors.ioResult;
 
 public final class IOUringDatagramChannel extends AbstractIOUringChannel implements DatagramChannel {
-    private static final ChannelMetadata METADATA = new ChannelMetadata(true);
+    private static final ChannelMetadata METADATA = new ChannelMetadata(true, 16);
     private static final String EXPECTED_TYPES =
             " (expected: " + StringUtil.simpleClassName(DatagramPacket.class) + ", " +
             StringUtil.simpleClassName(AddressedEnvelope.class) + '<' +


### PR DESCRIPTION
…mplementations

Motivation:

All hannel implementations used a MAX_MESSAGES_PER_READ of 1 due the fact of how they used the ChannelMetaData constructor. This makes no sense and hurts performance a lot as it will basically result in have fireChannelRead(...) only called once and then direct fireChannelReadComplete(...).

Modifications:

Use a default of 16 messages per read

Result:

Better performance with default settings