### PR TITLE
Upgrade java versions to latest patch release

### DIFF
--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -6,7 +6,7 @@ services:
     image: netty-io_uring:centos-6-1.8
     build:
       args:
-        java_version : "8.0.382-zulu"
+        java_version : "8.0.392-zulu"
 
   build-leak:
     image: netty-io_uring:centos-6-1.8

--- a/docker/docker-compose.centos-7.yaml
+++ b/docker/docker-compose.centos-7.yaml
@@ -9,7 +9,7 @@ services:
       dockerfile: docker/Dockerfile.centos7
       args:
         gcc_version: "10.2-2020.11"
-        java_version: "8.0.382-zulu"
+        java_version: "8.0.392-zulu"
 
   cross-compile-aarch64-common: &cross-compile-aarch64-common
     depends_on: [ cross-compile-aarch64-runtime-setup ]

--- a/docker/docker-compose.centos-7arm.yaml
+++ b/docker/docker-compose.centos-7arm.yaml
@@ -8,7 +8,7 @@ services:
       context: ../
       dockerfile: docker/Dockerfile.centos7arm64v8
       args:
-        java_version: "8.0.382-zulu"
+        java_version: "8.0.392-zulu"
 
   compile-aarch64-common: &compile-aarch64-common
     depends_on: [ compile-aarch64-runtime-setup ]


### PR DESCRIPTION
Motivation:

We didnt use the latest java releases on the CI

Modifications:

Update java releases

Result:

Use latest java releases on the CI