### PR TITLE
Remove old timeout when deadline changes

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUringEventLoop.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUringEventLoop.java
@@ -261,8 +261,12 @@ public final class IOUringEventLoop extends SingleThreadEventLoop {
             pendingWakeup = false;
             addEventFdRead(ringBuffer.ioUringSubmissionQueue());
         } else if (op == Native.IORING_OP_TIMEOUT) {
-            if (res == Native.ERRNO_ETIME_NEGATIVE && data == prevTimeoutGeneration) {
-                prevDeadlineNanos = NONE;
+            if (res == Native.ERRNO_ETIME_NEGATIVE) {
+                if (data == prevTimeoutGeneration) {
+                    prevDeadlineNanos = NONE;
+                } else {
+                    logger.trace("Timeout of previous generation timer");
+                }
             }
         } else if (op == Native.IORING_OP_TIMEOUT_REMOVE) {
             // do nothing

--- a/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUringSubmissionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUringSubmissionQueue.java
@@ -155,6 +155,10 @@ final class IOUringSubmissionQueue {
         return enqueueSqe(Native.IORING_OP_TIMEOUT, 0, 0, -1, timeoutMemoryAddress, 1, 0, extraData);
     }
 
+    boolean removeTimeout(short extraData) {
+        return enqueueSqe(Native.IORING_OP_TIMEOUT_REMOVE, 0, 0, -1, encode(-1, Native.IORING_OP_TIMEOUT, extraData), 0, 0, extraData);
+    }
+
     boolean addPollIn(int fd) {
         return addPoll(fd, Native.POLLIN);
     }

--- a/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/Native.java
@@ -140,6 +140,7 @@ final class Native {
     static final int ERRNO_ETIME_NEGATIVE = -NativeStaticallyReferencedJniMethods.etime();
     static final byte IORING_OP_POLL_ADD = NativeStaticallyReferencedJniMethods.ioringOpPollAdd();
     static final byte IORING_OP_TIMEOUT = NativeStaticallyReferencedJniMethods.ioringOpTimeout();
+    static final byte IORING_OP_TIMEOUT_REMOVE = NativeStaticallyReferencedJniMethods.ioringOpTimeoutRemove();
     static final byte IORING_OP_ACCEPT = NativeStaticallyReferencedJniMethods.ioringOpAccept();
     static final byte IORING_OP_READ = NativeStaticallyReferencedJniMethods.ioringOpRead();
     static final byte IORING_OP_WRITE = NativeStaticallyReferencedJniMethods.ioringOpWrite();

--- a/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/NativeStaticallyReferencedJniMethods.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/NativeStaticallyReferencedJniMethods.java
@@ -68,6 +68,7 @@ final class NativeStaticallyReferencedJniMethods {
     static native byte ioringOpPollAdd();
     static native byte ioringOpPollRemove();
     static native byte ioringOpTimeout();
+    static native byte ioringOpTimeoutRemove();
     static native byte ioringOpAccept();
     static native byte ioringOpRead();
     static native byte ioringOpWrite();

--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -491,6 +491,10 @@ static jbyte netty_io_uring_ioringOpTimeout(JNIEnv* env, jclass clazz) {
     return IORING_OP_TIMEOUT;
 }
 
+static jbyte netty_io_uring_ioringOpTimeoutRemove(JNIEnv* env, jclass clazz) {
+    return IORING_OP_TIMEOUT_REMOVE;
+}
+
 static jbyte netty_io_uring_ioringOpAccept(JNIEnv* env, jclass clazz) {
     return IORING_OP_ACCEPT;
 }
@@ -601,6 +605,7 @@ static const JNINativeMethod statically_referenced_fixed_method_table[] = {
   { "ioringOpPollAdd", "()B", (void *) netty_io_uring_ioringOpPollAdd },
   { "ioringOpPollRemove", "()B", (void *) netty_io_uring_ioringOpPollRemove },
   { "ioringOpTimeout", "()B", (void *) netty_io_uring_ioringOpTimeout },
+  { "ioringOpTimeoutRemove", "()B", (void *) netty_io_uring_ioringOpTimeoutRemove },
   { "ioringOpAccept", "()B", (void *) netty_io_uring_ioringOpAccept },
   { "ioringOpRead", "()B", (void *) netty_io_uring_ioringOpRead },
   { "ioringOpWrite", "()B", (void *) netty_io_uring_ioringOpWrite },

--- a/transport-native-io_uring/src/test/java/io/netty/incubator/channel/uring/NativeTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/incubator/channel/uring/NativeTest.java
@@ -165,6 +165,7 @@ public class NativeTest {
                     public void handle(int fd, int res, int flags, byte op, short mask) {
                         if (i == 0) {
                             assertEquals(Native.IORING_OP_TIMEOUT, op);
+                            // -ECANCELED
                             assertEquals(-125, res);
                         } else if (i == 1) {
                             assertEquals(Native.IORING_OP_TIMEOUT_REMOVE, op);

--- a/transport-native-io_uring/src/test/java/io/netty/incubator/channel/uring/NativeTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/incubator/channel/uring/NativeTest.java
@@ -159,20 +159,22 @@ public class NativeTest {
             public void run() {
                 completionQueue.ioUringWaitCqe();
                 completionQueue.process(new IOUringCompletionQueueCallback() {
-                    int i = 0;
+                    boolean seenTimeout = false;
+                    boolean seenTimeoutRemove = false;
 
                     @Override
                     public void handle(int fd, int res, int flags, byte op, short mask) {
-                        if (i == 0) {
-                            assertEquals(Native.IORING_OP_TIMEOUT, op);
+                        if (op == Native.IORING_OP_TIMEOUT) {
+                            assertFalse(seenTimeout);
+                            seenTimeout = true;
                             // -ECANCELED
                             assertEquals(-125, res);
-                        } else if (i == 1) {
-                            assertEquals(Native.IORING_OP_TIMEOUT_REMOVE, op);
+                        } else if (op == Native.IORING_OP_TIMEOUT_REMOVE) {
+                            assertFalse(seenTimeoutRemove);
+                            seenTimeoutRemove = true;
                         } else {
                             fail();
                         }
-                        i++;
                     }
                 });
                 completionQueue.ioUringWaitCqe();


### PR DESCRIPTION
I had a memory issue and @franz1981 suggested #211 as the cause. This patch is my fix for that bug, though I don't believe my mem issue was ultimately caused by this.

This PR does the legwork for adding ioringOpTimeoutRemove, and implementing a test. However two things can still be improved:

- [ ] could use IORING_TIMEOUT_UPDATE (see #211) to save one sqe.
- [x] there may be a race in IOUringEventLoop between the addTimeout and the IORING_OP_TIMEOUT handler. If the kernel fires a deadline cqe, then we send a deadline update sqe, and only then we process the first cqe, prevDeadlineNanos is NONE even though we've submitted a new deadline. I'm not sure if this can actually happen since deadline changes should only adjust the deadline downwards, not upwards? Not sure.