### PR TITLE
Minor allocation optimization

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/AbstractIOUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/AbstractIOUringStreamChannel.java
@@ -211,12 +211,13 @@ abstract class AbstractIOUringStreamChannel extends AbstractIOUringChannel imple
 
         private ByteBuf readBuffer;
         private IovArray iovArray;
+        private final ByteBuf iovArrayBuffer = alloc().directBuffer(Limits.IOV_MAX * IovArray.IOV_SIZE);
 
         @Override
         protected int scheduleWriteMultiple(ChannelOutboundBuffer in) {
             assert iovArray == null;
             int numElements = Math.min(in.size(), Limits.IOV_MAX);
-            ByteBuf iovArrayBuffer = alloc().directBuffer(numElements * IovArray.IOV_SIZE);
+            iovArrayBuffer.capacity(numElements * IovArray.IOV_SIZE);
             iovArray = new IovArray(iovArrayBuffer);
             try {
                 int offset = iovArray.count();
@@ -335,6 +336,7 @@ abstract class AbstractIOUringStreamChannel extends AbstractIOUringChannel imple
             if (iovArray != null) {
                 this.iovArray = null;
                 iovArray.release();
+                iovArrayBuffer.clear();
             }
             if (res >= 0) {
                 unsafe().outboundBuffer().removeBytes(res);


### PR DESCRIPTION
At the moment, for every multiple write operation an iov array buffer is allocated. Which cause some churn when there are high volume of writes. Considering at max there can be `Limits.IOV_MAX` values, creating the ByteBuf once and re-using it based on the elements in the schedule operation.