### PR TITLE
Update netty-tcnative to 2.0.63.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <checkstyle.version>8.38</checkstyle.version>
     <junit.version>5.9.0</junit.version>
     <netty.version>4.1.107.Final</netty.version>
-    <netty-tcnative-boringssl-static.version>2.0.61.Final</netty-tcnative-boringssl-static.version>
+    <netty-tcnative-boringssl-static.version>2.0.63.Final</netty-tcnative-boringssl-static.version>
     <bouncycastle.version>1.68</bouncycastle.version>
     <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
     <maven-bundle-plugin.version>5.1.1</maven-bundle-plugin.version>


### PR DESCRIPTION
Motivation:

We released a new version of netty-tcnative

Modifications:

Update to 2.0.63.Final

Result:

Use latest netty-tcnative release