### PR TITLE
Replace usage of mirrorlist with baseurl

### DIFF
--- a/docker/Dockerfile.centos7
+++ b/docker/Dockerfile.centos7
@@ -1,9 +1,12 @@
-FROM centos:7.9.2009
+FROM centos:7.6.1810
 
 ARG gcc_version=10.2-2020.11
 ENV GCC_VERSION $gcc_version
 ENV MAVEN_VERSION 3.9.1
 ENV SOURCE_DIR /root/source
+
+# Update as we need to use the vault now.
+RUN sed -i -e 's/^mirrorlist/#mirrorlist/g' -e 's/^#baseurl=http:\/\/mirror.centos.org\/centos\/$releasever\//baseurl=https:\/\/vault.centos.org\/\/7.6.1810\//g' /etc/yum.repos.d/CentOS-Base.repo
 
 # Install requirements
 RUN yum install -y \

--- a/docker/Dockerfile.centos7arm64v8
+++ b/docker/Dockerfile.centos7arm64v8
@@ -1,6 +1,9 @@
-FROM arm64v8/centos:7.9.2009
+FROM arm64v8/centos:7.6.1810
 
 ENV MAVEN_VERSION 3.9.1
+
+# Update as we need to use the vault now.
+RUN sed -i -e 's/^mirrorlist/#mirrorlist/g' -e 's/^#baseurl=http:\/\/mirror.centos.org\/centos\/$releasever\//baseurl=https:\/\/vault.centos.org\/\/7.6.1810\//g' /etc/yum.repos.d/CentOS-Base.repo
 
 # Install requirements
 RUN yum install -y \


### PR DESCRIPTION
Motivation:

We can't use the default mirrorlist anymore as it will fail and so fail the docker build

Modifications:

Use baseurl with the correct vault

Result:

Docker image can be build again