### PR TITLE
Port netty seccomp changes

### DIFF
--- a/docker/docker-compose.centos-6.yaml
+++ b/docker/docker-compose.centos-6.yaml
@@ -16,6 +16,8 @@ services:
       - ~/.m2/repository:/root/.m2/repository
       - ..:/code:delegated
     working_dir: /code
+    security_opt:
+      - seccomp:unconfined
 
   build-leak:
     <<: *common

--- a/docker/docker-compose.centos-7.yaml
+++ b/docker/docker-compose.centos-7.yaml
@@ -19,6 +19,8 @@ services:
       - ~/.m2/repository:/root/.m2/repository
       - ..:/code:delegated
     working_dir: /code
+    security_opt:
+      - seccomp:unconfined
 
   cross-compile-aarch64-deploy:
     <<: *cross-compile-aarch64-common


### PR DESCRIPTION
This ports over the changes from https://github.com/netty/netty/pull/14203, which makes the tests run in the docker containers again.