### PR TITLE
Upload hidden files for staging

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           name: ${{ matrix.setup }}-local-staging
           path: ~/local-staging
+          include-hidden-files: true
 
   deploy-staged-snapshots:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -72,6 +72,7 @@ jobs:
         with:
           name: prepare-release-workspace
           path: ${{ github.workspace }}/**
+          include-hidden-files: true
 
   stage-release:
     runs-on: ubuntu-latest
@@ -142,6 +143,7 @@ jobs:
         with:
           name: ${{ matrix.setup }}-local-staging
           path: ~/local-staging
+          include-hidden-files: true
 
       - name: Rollback release on failure
         working-directory: ./prepare-release-workspace/


### PR DESCRIPTION
Motivation:

Due a change in the upload action of github we now need to explicit enable the uplaod of hidden files (dot-files). Not doing this breaks our staging workflow which depends on some of these files.

See https://github.com/actions/upload-artifact/issues/602

Modifications:

Explicit set include-hidden-files: true

Result:

Staging works again