### PR TITLE
Add devcontainers for Linux

### DIFF
--- a/.devcontainer/ubuntu/Dockerfile
+++ b/.devcontainer/ubuntu/Dockerfile
@@ -1,0 +1,5 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
+RUN apt-get update && apt-get install -y \
+    autotools-dev autoconf automake libtool make tar libaio-dev libssl-dev libapr1-dev gcc \
+    htop strace  openjdk-8-jdk-headless openjdk-8-source openjdk-11-jdk-headless openjdk-11-source \
+    openjdk-17-jdk-headless openjdk-17-source openjdk-21-jdk-headless openjdk-21-source

--- a/.devcontainer/ubuntu/devcontainer.json
+++ b/.devcontainer/ubuntu/devcontainer.json
@@ -1,0 +1,10 @@
+{
+  name: "netty-on-ubuntu",
+  containerEnv: {
+    CPATH: "/usr/lib/jvm/java-21-openjdk-arm64/include/:/usr/lib/jvm/java-21-openjdk-arm64/include/linux/"
+  },
+  build: {
+    dockerfile: "Dockerfile",
+  },
+  "securityOpt": [ "seccomp=unconfined" ]
+}


### PR DESCRIPTION
Motivation:
Linux is the most important deployment OS, but a significant amount of development takes place on Windows and MacOS. Devcontainers allow developers to quickly spin up a Docker container, to run their IDE inside a native Linux environment. This is helpful for debugging and testing.
Intellij IDEA Ultimate and Visual Studio Code both have support for devcontainers.

Modifications:
Add devcontainer spec file for ubuntu

Result:
It's now possible to run an IDE in a Linux devcontainer environment on Windows and MacOS.