### PR TITLE
Explicit specify the platform for Docker files

### DIFF
--- a/docker/Dockerfile.centos6
+++ b/docker/Dockerfile.centos6
@@ -1,4 +1,4 @@
-FROM centos:6.10
+FROM --platform=linux/amd64 centos:6.10
 
 ENV MAVEN_VERSION 3.9.1
 

--- a/docker/Dockerfile.centos7
+++ b/docker/Dockerfile.centos7
@@ -1,4 +1,4 @@
-FROM centos:7.6.1810
+FROM --platform=linux/amd64 centos:7.6.1810
 
 ARG gcc_version=10.2-2020.11
 ENV GCC_VERSION $gcc_version

--- a/docker/Dockerfile.centos7arm64v8
+++ b/docker/Dockerfile.centos7arm64v8
@@ -1,4 +1,4 @@
-FROM arm64v8/centos:7.6.1810
+FROM --platform=linux/amd64 arm64v8/centos:7.6.1810
 
 ENV MAVEN_VERSION 3.9.1
 


### PR DESCRIPTION
Motivation:

We should explicit specify the platform we use for docker to ensure our build produce the correct artifacts

Modifications:

Add --platform=linux/amd64 to docker files

Result:

Ensure build produces correct artifacts