### PR TITLE
Log submission failures via tracing level as these are expected

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUringSubmissionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/incubator/channel/uring/IOUringSubmissionQueue.java
@@ -261,7 +261,8 @@ final class IOUringSubmissionQueue {
             if (ret < 0) {
                 throw new RuntimeException("ioUringEnter syscall returned " + ret);
             }
-            logger.warn("Not all submissions succeeded");
+            // some submission might fail if these are done inline and failed.
+            logger.trace("Not all submissions succeeded. Only {} of {} SQEs were submitted.", ret, toSubmit);
         }
         return ret;
     }


### PR DESCRIPTION
Motivation:

Sometimes submission of ops will fail if these are executed inline and return some error. This is expected and so we shouldn't log a warn message. That said it might still be useful to log these cases with trace level.

Modifications:

Log submission failures via tracing level

Result:

Use correct logging level that will not confuse people. This is a port of https://github.com/netty/netty/pull/14671