### PR TITLE
Add build profile for oss-fuzz compilation

### DIFF
--- a/transport-native-io_uring/pom.xml
+++ b/transport-native-io_uring/pom.xml
@@ -366,6 +366,12 @@
         <test.argLine>-Dio.netty.leakDetectionLevel=paranoid -Dio.netty.leakDetection.targetRecords=32</test.argLine>
       </properties>
     </profile>
+    <profile>
+      <id>oss-fuzz</id>
+      <properties>
+        <jni.compiler.args.cflags>CFLAGS=${env.CFLAGS} -I${unix.common.include.unpacked.dir}</jni.compiler.args.cflags>
+      </properties>
+    </profile>
   </profiles>
 
   <dependencies>

--- a/transport-native-io_uring/pom.xml
+++ b/transport-native-io_uring/pom.xml
@@ -370,7 +370,6 @@
       <id>oss-fuzz</id>
       <properties>
         <jni.compiler.args.cflags>CFLAGS=${env.CFLAGS} -I${unix.common.include.unpacked.dir}</jni.compiler.args.cflags>
-        <jni.compiler.args.ldflags>LDFLAGS=-L${unix.common.lib.unpacked.dir} -Wl,--no-as-needed -lrt -ldl -Wl,--whole-archive -l${unix.common.lib.name} -l:/usr/lib/libFuzzingEngine.a -Wl,--no-whole-archive</jni.compiler.args.ldflags>
       </properties>
     </profile>
   </profiles>

--- a/transport-native-io_uring/pom.xml
+++ b/transport-native-io_uring/pom.xml
@@ -370,6 +370,7 @@
       <id>oss-fuzz</id>
       <properties>
         <jni.compiler.args.cflags>CFLAGS=${env.CFLAGS} -I${unix.common.include.unpacked.dir}</jni.compiler.args.cflags>
+        <jni.compiler.args.ldflags>LDFLAGS=-L${unix.common.lib.unpacked.dir} -Wl,--no-as-needed -lrt -ldl -Wl,--whole-archive -l${unix.common.lib.name} -l:/usr/lib/libFuzzingEngine.a -Wl,--no-whole-archive</jni.compiler.args.ldflags>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
This profile replaces the CFLAGS with those from the environment so that the necessary fuzzing compilation flags are included.

This is used by https://github.com/yawkat/netty-fuzz-tests