### PR TITLE
Update to netty 4.1.118.Final and netty-tcnative 2.0.70.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,8 +77,8 @@
 
     <checkstyle.version>8.38</checkstyle.version>
     <junit.version>5.9.0</junit.version>
-    <netty.version>4.1.117.Final</netty.version>
-    <netty-tcnative-boringssl-static.version>2.0.69.Final</netty-tcnative-boringssl-static.version>
+    <netty.version>4.1.118.Final</netty.version>
+    <netty-tcnative-boringssl-static.version>2.0.70.Final</netty-tcnative-boringssl-static.version>
     <bouncycastle.version>1.68</bouncycastle.version>
     <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
     <maven-bundle-plugin.version>5.1.1</maven-bundle-plugin.version>


### PR DESCRIPTION
Motivation:

We released a new netty version

Modifications:

Update to netty 4.1.118.Final and netty-tcnative 2.0.70.Final

Result:

Use latest releases